### PR TITLE
onSuccess callback updated to reflect custom callback Url status

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,15 @@ function App() {
 
     await reclaimProofRequest.startSession({
       onSuccess: (proofs) => {
-        console.log('Verification success', proofs)
-        setProofs(proofs)
+        if (proofs && typeof proofs  === 'string') {
+            // When using a custom callback url, the proof is returned to the callback url and we get a message instead of a proof
+            console.log('SDK Message:', proofs)
+            setProofs(proofs)
+          } else if (proofs && typeof proofs !== 'string') {
+            // When using the default callback url, we get a proof
+            console.log('Proof received:', proofs?.claimData.context)
+            setProofs(proofs)
+          }
       },
       onFailure: (error) => {
         console.error('Verification failed', error)
@@ -149,7 +156,7 @@ Your Reclaim SDK demo should now be running. Click the "Create Claim" button to 
 
 3. **Status URL**: This URL (logged to the console) can be used to check the status of the claim process. It's useful for tracking the progress of verification.
 
-4. **Verification**: The `onSuccess` is called when verification is successful, providing the proof data.
+4. **Verification**: The `onSuccess` is called when verification is successful, providing the proof data. When using a custom callback url, the proof is returned to the callback url and we get a message instead of a proof.
 
 5. **Handling Failures**: The `onFailure` is called if verification fails, allowing you to handle errors gracefully.
 

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -29,12 +29,12 @@
       }
     },
     "..": {
-      "version": "1.3.10",
+      "name": "@reclaimprotocol/js-sdk",
+      "version": "2.0.5",
       "license": "See License in <https://github.com/reclaimprotocol/.github/blob/main/LICENSE>",
       "dependencies": {
         "canonicalize": "^2.0.0",
         "ethers": "^6.9.1",
-        "pino": "^8.19.0",
         "qs": "^6.11.2",
         "url-parse": "^1.5.10",
         "uuid": "^9.0.1"

--- a/example/src/app/page.tsx
+++ b/example/src/app/page.tsx
@@ -50,7 +50,7 @@ export default function Home() {
       // proofRequest.setRedirectUrl('https://example.com/redirect')
 
       // Set a custom app callback URL (if needed)
-      // proofRequest.setAppCallbackUrl('https://example.com/callback')
+      // proofRequest.setAppCallbackUrl('https://your-website.com/callback')
 
       // Uncomment the following line to log the proof request and to get the Json String
       // console.log('Proof request initialized:', proofRequest.toJsonString())
@@ -76,11 +76,16 @@ export default function Home() {
 
       // Start the verification session
       await reclaimProofRequest.startSession({
-        onSuccess: async (proof: Proof) => {
-          console.log('Proof received:', proof)
-
-
-          setExtracted(JSON.stringify(proof.claimData.context))
+        onSuccess: async (proof: Proof | string | undefined) => {
+          if (proof && typeof proof === 'string') {
+            // When using a custom callback url, the proof is returned to the callback url and we get a message instead of a proof
+            console.log('SDK Message:', proof)
+            setExtracted(proof)
+          } else if (proof && typeof proof !== 'string') {
+            // When using the default callback url, we get a proof
+            console.log('Proof received:', proof?.claimData.context)
+            setExtracted(JSON.stringify(proof?.claimData.context))
+          }
         },
         onError: (error: Error) => {
           console.error('Error in proof generation:', error)

--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -39,6 +39,8 @@ import { assertValidSignedClaim, createLinkWithTemplateData, generateRequestedPr
 import loggerModule from './utils/logger';
 const logger = loggerModule.logger
 
+const sdkVersion = require('../package.json').version;
+
 
 export async function verifyProof(proof: Proof): Promise<boolean> {
     if (!proof.signatures.length) {
@@ -136,7 +138,8 @@ export class ReclaimProofRequest {
             loggerModule.setLogLevel('silent');
         }
         this.options = options;
-        this.sdkVersion = 'js-2.1.0';
+        // Fetch sdk version from package.json
+        this.sdkVersion = sdkVersion;
         logger.info(`Initializing client with applicationId: ${this.applicationId}`);
     }
 

--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -25,12 +25,14 @@ import {
     InvalidParamError,
     NoProviderParamsError,
     ProofNotVerifiedError,
+    ProofSubmissionFailedError,
     ProviderFailedError,
     SessionNotStartedError,
     SetParamsError,
     SetSignatureError,
     SignatureGeneratingError,
-    SignatureNotFoundError} from './utils/errors'
+    SignatureNotFoundError
+} from './utils/errors'
 import { validateContext, validateFunctionParams, validateRequestedProof, validateSignature, validateURL } from './utils/validationUtils'
 import { fetchStatusUrl, initSession, updateSession } from './utils/sessionUtils'
 import { assertValidSignedClaim, createLinkWithTemplateData, generateRequestedProof, getFilledParameters, getWitnessesForClaim } from './utils/proofUtils'
@@ -120,6 +122,7 @@ export class ReclaimProofRequest {
     private redirectUrl?: string;
     private intervals: Map<string, NodeJS.Timer> = new Map();
     private timeStamp: string;
+    private sdkVersion: string;
 
     // Private constructor
     private constructor(applicationId: string, providerId: string, options?: ProofRequestOptions) {
@@ -133,6 +136,7 @@ export class ReclaimProofRequest {
             loggerModule.setLogLevel('silent');
         }
         this.options = options;
+        this.sdkVersion = 'js-2.0.6';
         logger.info(`Initializing client with applicationId: ${this.applicationId}`);
     }
 
@@ -189,7 +193,8 @@ export class ReclaimProofRequest {
                 redirectUrl,
                 timeStamp,
                 appCallbackUrl,
-                options
+                options,
+                sdkVersion
             }: ProofPropertiesJSON = JSON.parse(jsonString)
 
             validateFunctionParams([
@@ -198,6 +203,7 @@ export class ReclaimProofRequest {
                 { input: signature, paramName: 'signature', isString: true },
                 { input: sessionId, paramName: 'sessionId', isString: true },
                 { input: timeStamp, paramName: 'timeStamp', isString: true },
+                { input: sdkVersion, paramName: 'sdkVersion', isString: true },
             ], 'fromJsonString');
 
             validateRequestedProof(requestedProof);
@@ -222,7 +228,7 @@ export class ReclaimProofRequest {
             proofRequestInstance.redirectUrl = redirectUrl
             proofRequestInstance.timeStamp = timeStamp
             proofRequestInstance.signature = signature
-
+            proofRequestInstance.sdkVersion = sdkVersion;
             return proofRequestInstance
         } catch (error) {
             logger.info('Failed to parse JSON string in fromJsonString:', error);
@@ -385,7 +391,8 @@ export class ReclaimProofRequest {
             signature: this.signature,
             redirectUrl: this.redirectUrl,
             timeStamp: this.timeStamp,
-            options: this.options
+            options: this.options,
+            sdkVersion: this.sdkVersion
         })
     }
 
@@ -409,7 +416,8 @@ export class ReclaimProofRequest {
                 context: JSON.stringify(this.context),
                 parameters: getFilledParameters(requestedProof),
                 redirectUrl: this.redirectUrl ?? '',
-                acceptAiProviders: this.options?.acceptAiProviders ?? false
+                acceptAiProviders: this.options?.acceptAiProviders ?? false,
+                sdkVersion: this.sdkVersion
             }
 
             const link = await createLinkWithTemplateData(templateData)
@@ -424,40 +432,57 @@ export class ReclaimProofRequest {
 
     async startSession({ onSuccess, onError }: StartSessionParams): Promise<void> {
         if (!this.sessionId) {
-            const message = "Session can't be started due to undefined value of statusUrl and sessionId"
-            logger.info(message)
-            throw new SessionNotStartedError(message)
+            const message = "Session can't be started due to undefined value of sessionId";
+            logger.info(message);
+            throw new SessionNotStartedError(message);
         }
 
-        logger.info('Starting session')
+        logger.info('Starting session');
         const interval = setInterval(async () => {
             try {
-                const statusUrlResponse = await fetchStatusUrl(this.sessionId)
+                const statusUrlResponse = await fetchStatusUrl(this.sessionId);
 
-                if (!statusUrlResponse.session) return
-                if (statusUrlResponse.session.statusV2 === SessionStatus.PROOF_GENERATION_FAILED) throw new ProviderFailedError()
-                if (!statusUrlResponse.session.proofs || statusUrlResponse.session.proofs.length === 0) return
+                if (!statusUrlResponse.session) return;
+                if (statusUrlResponse.session.statusV2 === SessionStatus.PROOF_GENERATION_FAILED) {
+                    throw new ProviderFailedError();
+                }
 
-                const proof = statusUrlResponse.session.proofs[0]
-                const verified = await verifyProof(proof)
-                if (!verified) {
-                    logger.info(`Proof not verified: ${proof}`)
-                    throw new ProofNotVerifiedError()
+                const isDefaultCallbackUrl = this.getAppCallbackUrl() === `${constants.DEFAULT_RECLAIM_CALLBACK_URL}${this.sessionId}`;
+
+                if (isDefaultCallbackUrl) {
+                    if (statusUrlResponse.session.proofs && statusUrlResponse.session.proofs.length > 0) {
+                        const proof = statusUrlResponse.session.proofs[0];
+                        const verified = await verifyProof(proof);
+                        if (!verified) {
+                            logger.info(`Proof not verified: ${JSON.stringify(proof)}`);
+                            throw new ProofNotVerifiedError();
+                        }
+                        if (onSuccess) {
+                            onSuccess(proof);
+                        }
+                        this.clearInterval();
+                    }
+                } else {
+                    if (statusUrlResponse.session.statusV2 === SessionStatus.PROOF_SUBMISSION_FAILED) {
+                        throw new ProofSubmissionFailedError();
+                    }
+                    if (statusUrlResponse.session.statusV2 === SessionStatus.PROOF_SUBMITTED) {
+                        if (onSuccess) {
+                            onSuccess('Proof submitted successfully to the custom callback url');
+                        }
+                        this.clearInterval();
+                    }
                 }
-                if (onSuccess) {
-                    onSuccess(proof)
-                }
-                this.clearInterval()
             } catch (e) {
                 if (onError) {
-                    onError(e as Error)
+                    onError(e as Error);
                 }
-                this.clearInterval()
+                this.clearInterval();
             }
-        }, 3000)
+        }, 3000);
 
-        this.intervals.set(this.sessionId, interval)
-        scheduleIntervalEndingTask(this.sessionId, this.intervals, onError)
+        this.intervals.set(this.sessionId, interval);
+        scheduleIntervalEndingTask(this.sessionId, this.intervals, onError);
     }
 }
 

--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -136,7 +136,7 @@ export class ReclaimProofRequest {
             loggerModule.setLogLevel('silent');
         }
         this.options = options;
-        this.sdkVersion = 'js-2.0.6';
+        this.sdkVersion = 'js-2.1.0';
         logger.info(`Initializing client with applicationId: ${this.applicationId}`);
     }
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -34,3 +34,4 @@ export const SetSignatureError = createErrorClass('SetSignatureError');
 export const GetAppCallbackUrlError = createErrorClass("GetAppCallbackUrlError");
 export const GetRequestUrlError = createErrorClass('GetRequestUrlError');
 export const StatusUrlError = createErrorClass('StatusUrlError');
+export const ProofSubmissionFailedError = createErrorClass('ProofSubmissionFailedError');

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -26,7 +26,7 @@ export type StartSessionParams = {
   onError: OnError;
 };
 
-export type OnSuccess = (proof: Proof) => void;
+export type OnSuccess = (proof?: Proof | string) => void;
 export type OnError = (error: Error) => void;
 
 export type ProofRequestOptions = {
@@ -54,6 +54,7 @@ export enum SessionStatus {
   PROOF_GENERATION_SUCCESS = 'PROOF_GENERATION_SUCCESS',
   PROOF_GENERATION_FAILED = 'PROOF_GENERATION_FAILED',
   PROOF_SUBMITTED = 'PROOF_SUBMITTED',
+  PROOF_SUBMISSION_FAILED = 'PROOF_SUBMISSION_FAILED',
   PROOF_MANUAL_VERIFICATION_SUBMITED = 'PROOF_MANUAL_VERIFICATION_SUBMITED',
 };
 
@@ -69,6 +70,7 @@ export type ProofPropertiesJSON = {
   timeStamp: string;
   appCallbackUrl?: string;
   options?: ProofRequestOptions;
+  sdkVersion: string;
 };
 
 export type TemplateData = {
@@ -82,6 +84,7 @@ export type TemplateData = {
   parameters: { [key: string]: string | string };
   redirectUrl: string;
   acceptAiProviders: boolean;
+  sdkVersion: string;
 };
 
 // Add the new StatusUrlResponse type


### PR DESCRIPTION
### Description
onSuccess callback now reflects that status for the custom callback url too. Once proof are successfully submitted on to custom callback url, we get a message in onSuccess callback to notify about it to the client.

### Testing (ignore for documentation update)
Example demo when the custom callback url is set while using the sdk
<img width="1108" alt="Screenshot 2024-10-22 at 11 52 31 PM" src="https://github.com/user-attachments/assets/44382202-2a73-4590-8faa-4ed4ce9204ab">
<img width="1700" alt="Screenshot 2024-10-22 at 11 53 01 PM" src="https://github.com/user-attachments/assets/a54a6067-9392-47b7-9756-1c3de3ee9908">



### Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

### Checklist:
- [x] I have read and agree to the [Code of Conduct](https://github.com/reclaimprotocol/.github/blob/main/Code-of-Conduct.md).
- [x] I have signed the [Contributor License Agreement (CLA)](https://github.com/reclaimprotocol/.github/blob/main/CLA.md).
- [x] I have considered the [Security Policy](https://github.com/reclaimprotocol/.github/blob/main/SECURITY.md).
- [x] I have self-reviewed and tested my code.
- [x] I have updated documentation as needed.
- [x] I agree to the [project's custom license](https://github.com/reclaimprotocol/.github/blob/main/LICENSE).
