### PR TITLE
Added a field in setAppCallbackUrl to specify the return type for proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,9 @@ The Reclaim SDK offers several advanced options to customize your integration:
 
 4. **Custom Callback URL**:
    Set a custom callback URL for your app which allows you to receive proofs and status updates on your callback URL:
+   Pass in `jsonProofResponse: true` to receive the proof in JSON format: By default, the proof is returned as a url encoded string.
    ```javascript
-   reclaimProofRequest.setAppCallbackUrl('https://example.com/callback')
+   reclaimProofRequest.setAppCallbackUrl('https://example.com/callback', true)
    ```
 
 5. **Exporting and Importing SDK Configuration**:

--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -125,6 +125,7 @@ export class ReclaimProofRequest {
     private intervals: Map<string, NodeJS.Timer> = new Map();
     private timeStamp: string;
     private sdkVersion: string;
+    private jsonProofResponse: boolean = false;
 
     // Private constructor
     private constructor(applicationId: string, providerId: string, options?: ProofRequestOptions) {
@@ -197,7 +198,8 @@ export class ReclaimProofRequest {
                 timeStamp,
                 appCallbackUrl,
                 options,
-                sdkVersion
+                sdkVersion,
+                jsonProofResponse
             }: ProofPropertiesJSON = JSON.parse(jsonString)
 
             validateFunctionParams([
@@ -223,6 +225,12 @@ export class ReclaimProofRequest {
                 validateContext(context);
             }
 
+            if (jsonProofResponse !== undefined) {
+                validateFunctionParams([
+                    { input: jsonProofResponse, paramName: 'jsonProofResponse' }
+                ], 'fromJsonString');
+            }
+
             const proofRequestInstance = new ReclaimProofRequest(applicationId, providerId, options);
             proofRequestInstance.sessionId = sessionId;
             proofRequestInstance.context = context;
@@ -240,9 +248,10 @@ export class ReclaimProofRequest {
     }
 
     // Setter methods
-    setAppCallbackUrl(url: string): void {
+    setAppCallbackUrl(url: string, jsonProofResponse?: boolean): void {
         validateURL(url, 'setAppCallbackUrl')
         this.appCallbackUrl = url
+        this.jsonProofResponse = jsonProofResponse ?? false
     }
 
     setRedirectUrl(url: string): void {
@@ -395,7 +404,8 @@ export class ReclaimProofRequest {
             redirectUrl: this.redirectUrl,
             timeStamp: this.timeStamp,
             options: this.options,
-            sdkVersion: this.sdkVersion
+            sdkVersion: this.sdkVersion,
+            jsonProofResponse: this.jsonProofResponse
         })
     }
 
@@ -420,7 +430,8 @@ export class ReclaimProofRequest {
                 parameters: getFilledParameters(requestedProof),
                 redirectUrl: this.redirectUrl ?? '',
                 acceptAiProviders: this.options?.acceptAiProviders ?? false,
-                sdkVersion: this.sdkVersion
+                sdkVersion: this.sdkVersion,
+                jsonProofResponse: this.jsonProofResponse
             }
 
             const link = await createLinkWithTemplateData(templateData)

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -71,6 +71,7 @@ export type ProofPropertiesJSON = {
   appCallbackUrl?: string;
   options?: ProofRequestOptions;
   sdkVersion: string;
+  jsonProofResponse?: boolean;
 };
 
 export type TemplateData = {
@@ -85,6 +86,7 @@ export type TemplateData = {
   redirectUrl: string;
   acceptAiProviders: boolean;
   sdkVersion: string;
+  jsonProofResponse?: boolean;
 };
 
 // Add the new StatusUrlResponse type


### PR DESCRIPTION
### Description
Added an additional optional field in setAppCallbackUrl to specify the proof type to receive in the custom callback url

### Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

### Checklist:
- [x] I have read and agree to the [Code of Conduct](https://github.com/reclaimprotocol/.github/blob/main/Code-of-Conduct.md).
- [x] I have signed the [Contributor License Agreement (CLA)](https://github.com/reclaimprotocol/.github/blob/main/CLA.md).
- [x] I have considered the [Security Policy](https://github.com/reclaimprotocol/.github/blob/main/SECURITY.md).
- [x] I have self-reviewed and tested my code.
- [x] I have updated documentation as needed.
- [x] I agree to the [project's custom license](https://github.com/reclaimprotocol/.github/blob/main/LICENSE).
