### PR TITLE
Added Support for Cascading Providers in the verifyProof method

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,12 @@ function App() {
             setProofs(proofs)
           } else if (proofs && typeof proofs !== 'string') {
             // When using the default callback url, we get a proof
-            console.log('Proof received:', proofs?.claimData.context)
+            if (Array.isArray(proofs)) {
+              // when using the cascading providers, providers having more than one proof will return an array of proofs
+              console.log(JSON.stringify(proofs.map(p => p.claimData.context)))
+            } else {
+              console.log('Proof received:', proofs?.claimData.context)
+            }
             setProofs(proofs)
           }
       },

--- a/example/src/app/page.tsx
+++ b/example/src/app/page.tsx
@@ -34,9 +34,8 @@ export default function Home() {
       const proofRequest = await ReclaimProofRequest.init(
         process.env.NEXT_PUBLIC_RECLAIM_APP_ID!,
         process.env.NEXT_PUBLIC_RECLAIM_APP_SECRET!,
-        '5eb7f8b3-cbe8-4001-848e-cb161e53fe60', // providerId
-        // Uncomment the following line to enable logging and AI providers
-        // { log: true, acceptAiProviders: true }
+        process.env.NEXT_PUBLIC_RECLAIM_PROVIDER_ID!,
+        { log: true }
       )
       setReclaimProofRequest(proofRequest)
 
@@ -44,13 +43,13 @@ export default function Home() {
       proofRequest.addContext('0x00000000000', 'Example context message')
 
       // Set parameters for the proof request (if needed)
-      // proofRequest.setParams({ email: "test@example.com", userName: "testUser" })
+      // proofRequest.setParams({ key: "value" })
 
       // Set a redirect URL (if needed)
-      // proofRequest.setRedirectUrl('https://example.com/redirect')
+      // proofRequest.setRedirectUrl('your-redirect-url')
 
       // Set a custom app callback URL (if needed)
-      // proofRequest.setAppCallbackUrl('https://your-website.com/callback')
+      // proofRequest.setAppCallbackUrl('your-callback-url')
 
       // Uncomment the following line to log the proof request and to get the Json String
       // console.log('Proof request initialized:', proofRequest.toJsonString())
@@ -76,15 +75,19 @@ export default function Home() {
 
       // Start the verification session
       await reclaimProofRequest.startSession({
-        onSuccess: async (proof: Proof | string | undefined) => {
+        onSuccess: async (proof: Proof | Proof[] | string | undefined) => {
           if (proof && typeof proof === 'string') {
             // When using a custom callback url, the proof is returned to the callback url and we get a message instead of a proof
             console.log('SDK Message:', proof)
             setExtracted(proof)
           } else if (proof && typeof proof !== 'string') {
             // When using the default callback url, we get a proof
-            console.log('Proof received:', proof?.claimData.context)
-            setExtracted(JSON.stringify(proof?.claimData.context))
+            console.log('Proof received:', proof)
+            if (Array.isArray(proof)) {
+              setExtracted(JSON.stringify(proof.map(p => p.claimData.context)))
+            } else {
+              setExtracted(JSON.stringify(proof?.claimData.context))
+            }
           }
         },
         onError: (error: Error) => {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -26,7 +26,7 @@ export type StartSessionParams = {
   onError: OnError;
 };
 
-export type OnSuccess = (proof?: Proof | string) => void;
+export type OnSuccess = (proof?: Proof | Proof[] | string) => void;
 export type OnError = (error: Error) => void;
 
 export type ProofRequestOptions = {


### PR DESCRIPTION
### Description
Adding Support for Cascading Providers for verify proof method to accept an array of Proofs

### Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

### Checklist:
- [x] I have read and agree to the [Code of Conduct](https://github.com/reclaimprotocol/.github/blob/main/Code-of-Conduct.md).
- [x] I have signed the [Contributor License Agreement (CLA)](https://github.com/reclaimprotocol/.github/blob/main/CLA.md).
- [x] I have considered the [Security Policy](https://github.com/reclaimprotocol/.github/blob/main/SECURITY.md).
- [x] I have self-reviewed and tested my code.
- [x] I have updated documentation as needed.
- [x] I agree to the [project's custom license](https://github.com/reclaimprotocol/.github/blob/main/LICENSE).
