### PR TITLE
feat: add support for onMeChain type

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -30,7 +30,7 @@
     },
     "..": {
       "name": "@reclaimprotocol/js-sdk",
-      "version": "2.1.1",
+      "version": "3.0.0",
       "license": "See License in <https://github.com/reclaimprotocol/.github/blob/main/LICENSE>",
       "dependencies": {
         "canonicalize": "^2.0.0",

--- a/example/src/app/page.tsx
+++ b/example/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 import React, { useEffect, useState } from 'react'
-import { ReclaimProofRequest } from '@reclaimprotocol/js-sdk'
+import { ReclaimProofRequest, ClaimCreationType } from '@reclaimprotocol/js-sdk'
 import { Proof } from '@reclaimprotocol/js-sdk'
 import { useQRCode } from 'next-qrcode'
 import Link from 'next/link'
@@ -50,6 +50,9 @@ export default function Home() {
 
       // Set a custom app callback URL (if needed)
       // proofRequest.setAppCallbackUrl('your-callback-url')
+
+      // Set the claim creation type (only if you want to create a claim on mechain)
+      // proofRequest.setClaimCreationType(ClaimCreationType.ON_ME_CHAIN)
 
       // Uncomment the following line to log the proof request and to get the Json String
       // console.log('Proof request initialized:', proofRequest.toJsonString())

--- a/package-lock.json
+++ b/package-lock.json
@@ -2458,6 +2458,16 @@
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
+    "node_modules/@bconnorwhite/bob/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@bconnorwhite/bob/node_modules/yargs": {
       "version": "15.4.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
@@ -10457,6 +10467,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/husky/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -14331,6 +14351,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-package-json-lint/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/npm-package-json-lint/node_modules/yargs-parser": {
@@ -20409,12 +20439,18 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
       "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/yargs": {

--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -1,12 +1,13 @@
 import type { Proof, Context } from './utils/interfaces'
 import { getIdentifierFromClaimInfo } from './witness'
-import type {
+import {
     SignedClaim,
     ProofRequestOptions,
     StartSessionParams,
     ProofPropertiesJSON,
     TemplateData,
-    InitSessionResponse
+    InitSessionResponse,
+    ClaimCreationType,
 } from './utils/types'
 import { SessionStatus } from './utils/types'
 import { ethers } from 'ethers'
@@ -130,6 +131,7 @@ export class ReclaimProofRequest {
     private sessionId: string;
     private options?: ProofRequestOptions;
     private context: Context = { contextAddress: '0x0', contextMessage: 'sample context' };
+    private claimCreationType?: ClaimCreationType = ClaimCreationType.STANDALONE;
     private providerId: string;
     private parameters: { [key: string]: string };
     private redirectUrl?: string;
@@ -292,6 +294,10 @@ export class ReclaimProofRequest {
     setRedirectUrl(url: string): void {
         validateURL(url, 'setRedirectUrl');
         this.redirectUrl = url;
+    }
+
+    setClaimCreationType(claimCreationType: ClaimCreationType): void {
+        this.claimCreationType = claimCreationType;
     }
 
     addContext(address: string, message: string): void {
@@ -480,10 +486,12 @@ export class ReclaimProofRequest {
                 if (isDefaultCallbackUrl) {
                     if (statusUrlResponse.session.proofs && statusUrlResponse.session.proofs.length > 0) {
                         const proofs = statusUrlResponse.session.proofs;
-                        const verified = await verifyProof(proofs);
-                        if (!verified) {
-                            logger.info(`Proofs not verified: ${JSON.stringify(proofs)}`);
-                            throw new ProofNotVerifiedError();
+                        if (this.claimCreationType === ClaimCreationType.STANDALONE) {
+                            const verified = await verifyProof(proofs);
+                            if (!verified) {
+                                logger.info(`Proofs not verified: ${JSON.stringify(proofs)}`);
+                                throw new ProofNotVerifiedError();
+                            }
                         }
                         // check if the proofs array has only one proof then send the proofs in onSuccess 
                         if (proofs.length === 1) {

--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -231,6 +231,7 @@ export class ReclaimProofRequest {
                 redirectUrl,
                 timeStamp,
                 appCallbackUrl,
+                claimCreationType,
                 options,
                 sdkVersion,
                 jsonProofResponse
@@ -260,6 +261,12 @@ export class ReclaimProofRequest {
 
             if (parameters) {
                 validateParameters(parameters);
+            }
+
+            if (claimCreationType) {
+                validateFunctionParams([
+                    { input: claimCreationType, paramName: 'claimCreationType' }
+                ], 'fromJsonString');
             }
 
             if (jsonProofResponse !== undefined) {
@@ -390,6 +397,7 @@ export class ReclaimProofRequest {
             sessionId: this.sessionId,
             context: this.context,
             appCallbackUrl: this.appCallbackUrl,
+            claimCreationType: this.claimCreationType,
             parameters: this.parameters,
             signature: this.signature,
             redirectUrl: this.redirectUrl,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './Reclaim';
 export * from './utils/interfaces';
+export { ClaimCreationType } from './utils/types';

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -6,7 +6,7 @@ export interface Proof {
   witnesses: WitnessData[];
   extractedParameterValues: any;
   publicData?: { [key: string]: string };
-  taskId?: string;
+  taskId?: number;
 }
 
 export interface WitnessData {

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -6,6 +6,7 @@ export interface Proof {
   witnesses: WitnessData[];
   extractedParameterValues: any;
   publicData?: { [key: string]: string };
+  taskId?: string;
 }
 
 export interface WitnessData {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -77,6 +77,7 @@ export type ProofPropertiesJSON = {
   parameters: { [key: string]: string };
   timeStamp: string;
   appCallbackUrl?: string;
+  claimCreationType?: ClaimCreationType;
   options?: ProofRequestOptions;
   sdkVersion: string;
   jsonProofResponse?: boolean;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -37,6 +37,12 @@ export type ProofRequestOptions = {
   envUrl?: string;
 };
 
+// Claim creation type enum
+export enum ClaimCreationType {
+  STANDALONE = 'createClaim',
+  ON_ME_CHAIN = 'createClaimOnMechain'
+}
+
 // Session and response types
 export type InitSessionResponse = {
   sessionId: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for configuring claim creation modes, allowing selection between standalone and "mechain" options.
  - Added a new claim creation type setting to proof requests.
  - Extended proof data to optionally include a task identifier.

- **Documentation**
  - Provided an example of how to set the claim creation type in proof requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->