### PR TITLE
feat: add device detection for (ios/android) and enable appClip default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reclaimprotocol/js-sdk",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Designed to request proofs from the Reclaim protocol and manage the flow of claims and witness interactions.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reclaimprotocol/js-sdk",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Designed to request proofs from the Reclaim protocol and manage the flow of claims and witness interactions.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -175,7 +175,11 @@ export class ReclaimProofRequest {
                 { paramName: 'appSecret', input: appSecret, isString: true }
             ], 'the constructor')
 
-            if (options && !options.device) {
+            if (!options) {
+                options = {};
+            }
+
+            if (!options.device) {
                 if (userAgentIsIOS) {
                     options.device = "ios";
                 } else if (userAgentIsAndroid) {

--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -9,7 +9,7 @@ import {
     InitSessionResponse,
     ClaimCreationType,
 } from './utils/types'
-import { SessionStatus } from './utils/types'
+import { SessionStatus, DeviceType } from './utils/types'
 import { ethers } from 'ethers'
 import canonicalize from 'canonicalize'
 import {
@@ -150,6 +150,23 @@ export class ReclaimProofRequest {
         this.applicationId = applicationId;
         this.sessionId = "";
         this.parameters = {};
+        
+        if (!options) {
+            options = {};
+        }
+
+        if (!options.device) {
+            if (userAgentIsIOS) {
+                options.device = DeviceType.IOS;
+            } else if (userAgentIsAndroid) {
+                options.device = DeviceType.ANDROID;
+            }
+        }
+
+        if (options.useAppClip === undefined) {
+            options.useAppClip = true;
+        }
+
         if (options?.log) {
             loggerModule.setLogLevel('info');
         } else {
@@ -174,18 +191,6 @@ export class ReclaimProofRequest {
                 { paramName: 'providerId', input: providerId, isString: true },
                 { paramName: 'appSecret', input: appSecret, isString: true }
             ], 'the constructor')
-
-            if (!options) {
-                options = {};
-            }
-
-            if (!options.device) {
-                if (userAgentIsIOS) {
-                    options.device = "ios";
-                } else if (userAgentIsAndroid) {
-                    options.device = "android";
-                }
-             }
 
             // check if options is provided and validate each property of options
             if (options) {

--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -35,6 +35,7 @@ import {
 import { validateContext, validateFunctionParams, validateParameters, validateSignature, validateURL } from './utils/validationUtils'
 import { fetchStatusUrl, initSession, updateSession } from './utils/sessionUtils'
 import { assertValidSignedClaim, createLinkWithTemplateData, getWitnessesForClaim } from './utils/proofUtils'
+import { userAgentIsAndroid, userAgentIsIOS } from './utils/device'
 import loggerModule from './utils/logger';
 const logger = loggerModule.logger
 
@@ -174,6 +175,14 @@ export class ReclaimProofRequest {
                 { paramName: 'appSecret', input: appSecret, isString: true }
             ], 'the constructor')
 
+            if (options && !options.device) {
+                if (userAgentIsIOS) {
+                    options.device = "ios";
+                } else if (userAgentIsAndroid) {
+                    options.device = "android";
+                }
+             }
+
             // check if options is provided and validate each property of options
             if (options) {
                 if (options.acceptAiProviders) {
@@ -185,6 +194,9 @@ export class ReclaimProofRequest {
                     validateFunctionParams([
                         { paramName: 'log', input: options.log }
                     ], 'the constructor')
+                }
+                if (options.useAppClip === undefined) {
+                    options.useAppClip = true;
                 }
                 if (options.useAppClip) {
                     validateFunctionParams([

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -1,9 +1,19 @@
-// * There isn't a uniform/universal way to detect if the user is browsing a webpage from a mobile device, but this seems to work most of the time and might be enough for our case.
-const userAgent = typeof navigator !== 'undefined' ? navigator.userAgent.toLowerCase() : '';
+const navigatorDefined = typeof navigator !== 'undefined';
 const windowDefined = typeof window !== 'undefined';
+
+const userAgent = navigatorDefined ? navigator.userAgent.toLowerCase() : '';
+const userAgentData = navigatorDefined ? (navigator as Navigator & { userAgentData?: { platform: string } }).userAgentData : undefined;
 
 export const userAgentIsAndroid = userAgent.includes("android");
 
-const isIPadOS13Plus = windowDefined && navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
+const isIpad =
+  windowDefined &&
+  navigatorDefined &&
+  (userAgentData?.platform === 'iPad' || userAgent.includes('ipad'));
 
-export const userAgentIsIOS = /iphone|ipad|ipod/i.test(userAgent) || isIPadOS13Plus;
+export const userAgentIsIOS =
+  /iphone|ipod/i.test(userAgent) || isIpad;
+
+export const userAgentIsMobile =
+  /android|webos|iphone|ipad|ipod|blackberry|iemobile|opera mini/i.test(userAgent) ||
+  (windowDefined && 'orientation' in window);

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -1,0 +1,9 @@
+// * There isn't a uniform/universal way to detect if the user is browsing a webpage from a mobile device, but this seems to work most of the time and might be enough for our case.
+const userAgent = typeof navigator !== 'undefined' ? navigator.userAgent.toLowerCase() : '';
+const windowDefined = typeof window !== 'undefined';
+
+export const userAgentIsAndroid = userAgent.includes("android");
+
+const isIPadOS13Plus = windowDefined && navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
+
+export const userAgentIsIOS = /iphone|ipad|ipod/i.test(userAgent) || isIPadOS13Plus;

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -19,5 +19,3 @@ export const userAgentIsIOS =
 export const userAgentIsMobile =
     new RegExp(`${DeviceType.ANDROID}|webos|${DeviceType.IOS}|${DeviceType.IPAD}|ipod|blackberry|iemobile|opera mini`, 'i').test(userAgent) ||
     (windowDefined && 'orientation' in window);
-
-export { DeviceType };

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -1,19 +1,23 @@
+import { DeviceType } from "./types";
+
 const navigatorDefined = typeof navigator !== 'undefined';
 const windowDefined = typeof window !== 'undefined';
 
 const userAgent = navigatorDefined ? navigator.userAgent.toLowerCase() : '';
 const userAgentData = navigatorDefined ? (navigator as Navigator & { userAgentData?: { platform: string } }).userAgentData : undefined;
 
-export const userAgentIsAndroid = userAgent.includes("android");
+export const userAgentIsAndroid = userAgent.includes(DeviceType.ANDROID);
 
 const isIpad =
-  windowDefined &&
-  navigatorDefined &&
-  (userAgentData?.platform === 'iPad' || userAgent.includes('ipad'));
+    windowDefined &&
+    navigatorDefined &&
+    (userAgentData?.platform === DeviceType.IPAD || userAgent.includes(DeviceType.IPAD));
 
 export const userAgentIsIOS =
-  /iphone|ipod/i.test(userAgent) || isIpad;
+    new RegExp(`${DeviceType.IOS}|ipod`, 'i').test(userAgent) || isIpad;
 
 export const userAgentIsMobile =
-  /android|webos|iphone|ipad|ipod|blackberry|iemobile|opera mini/i.test(userAgent) ||
-  (windowDefined && 'orientation' in window);
+    new RegExp(`${DeviceType.ANDROID}|webos|${DeviceType.IOS}|${DeviceType.IPAD}|ipod|blackberry|iemobile|opera mini`, 'i').test(userAgent) ||
+    (windowDefined && 'orientation' in window);
+
+export { DeviceType };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -43,6 +43,14 @@ export enum ClaimCreationType {
   ON_ME_CHAIN = 'createClaimOnMechain'
 }
 
+// Device type enum 
+export enum DeviceType {
+    ANDROID = 'android',
+    IOS = 'ios',
+    IPAD = 'ipad'
+}
+
+
 // Session and response types
 export type InitSessionResponse = {
   sessionId: string;


### PR DESCRIPTION
### Description
This PR introduces automatic detection of the user's device platform (iOS or Android) to streamline SDK configuration. By auto-configuring optimal settings based on the detected platform, this eliminates the need for manual setup and enhances the developer experience

### Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

### Checklist:
- [x] I have read and agree to the [Code of Conduct](https://github.com/reclaimprotocol/.github/blob/main/Code-of-Conduct.md).
- [x] I have signed the [Contributor License Agreement (CLA)](https://github.com/reclaimprotocol/.github/blob/main/CLA.md).
- [x] I have considered the [Security Policy](https://github.com/reclaimprotocol/.github/blob/main/SECURITY.md).
- [x] I have self-reviewed and tested my code.
- [x] I have updated documentation as needed.
- [x] I agree to the [project's custom license](https://github.com/reclaimprotocol/.github/blob/main/LICENSE).

### Additional Notes:
- This change is backward-compatible and gracefully falls back to manual settings if detection fails.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Device type (iOS or Android) is now automatically detected and set by default when initializing a proof request.
	- App clip usage is automatically enabled by default if not specified.
- **Chores**
	- Updated package version to 3.0.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->