### PR TITLE
Added an option to disable the install extension button for desktop flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reclaimprotocol/js-sdk",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Designed to request proofs from the Reclaim protocol and manage the flow of claims and witness interactions.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -396,17 +396,38 @@ export class ReclaimProofRequest {
 
             if (options.extensionUrl !== undefined) {
                 validateURL(options.extensionUrl, 'setModalOptions');
+                validateFunctionParams([
+                    { input: options.extensionUrl, paramName: 'extensionUrl', isString: true }
+                ], 'setModalOptions');
             }
 
             if (options.darkTheme !== undefined) {
+                // check if the darkTheme is a boolean
+                if (typeof options.darkTheme !== 'boolean') {
+                    throw new InvalidParamError('darkTheme prop must be a boolean');
+                }
                 validateFunctionParams([
                     { input: options.darkTheme, paramName: 'darkTheme' }
                 ], 'setModalOptions');
             }
 
             if (options.modalPopupTimer !== undefined) {
+                // check if the modalPopupTimer is a positive whole number
+                if (typeof options.modalPopupTimer !== 'number' || options.modalPopupTimer <= 0 || !Number.isInteger(options.modalPopupTimer)) {
+                    throw new InvalidParamError('modalPopupTimer prop must be a valid time in minutes');
+                }
                 validateFunctionParams([
                     { input: options.modalPopupTimer, paramName: 'modalPopupTimer' }
+                ], 'setModalOptions');
+            }
+
+            if (options.showExtensionInstallButton !== undefined) {
+                // check if the showExtensionInstallButton is a boolean
+                if (typeof options.showExtensionInstallButton !== 'boolean') {
+                    throw new InvalidParamError('showExtensionInstallButton prop must be a boolean');
+                }
+                validateFunctionParams([
+                    { input: options.showExtensionInstallButton, paramName: 'showExtensionInstallButton' }
                 ], 'setModalOptions');
             }
 

--- a/src/utils/modalUtils.ts
+++ b/src/utils/modalUtils.ts
@@ -18,6 +18,7 @@ export class QRCodeModal {
             extensionUrl: constants.CHROME_EXTENSION_URL,
             darkTheme: false,
             modalPopupTimer: 1,  // default to 1 minute
+            showExtensionInstallButton: true, // default to true
             ...options
         };
     }
@@ -166,6 +167,7 @@ export class QRCodeModal {
                         display: inline-block;
                     "></div>
                     
+                    ${this.options.showExtensionInstallButton ? `
                     <div style="
                         margin-bottom: 24px;
                         padding: 16px;
@@ -202,7 +204,7 @@ export class QRCodeModal {
                            onmouseout="this.style.backgroundColor='${styles.extensionButtonBackground}'">
                             Install Extension
                         </a>
-                    </div>
+                    </div>` : ''}
                     
                     <div style="margin-top: 16px;">
                         <div id="reclaim-countdown" style="

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -47,6 +47,7 @@ export type ModalOptions = {
   extensionUrl?: string;
   darkTheme?: boolean;
   modalPopupTimer?: number;
+  showExtensionInstallButton?: boolean;
   onClose?: () => void;
 };
 


### PR DESCRIPTION
### Description
Added an option to disable the install extension button for desktop modal popup options

### Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

### Checklist:
- [x] I have read and agree to the [Code of Conduct](https://github.com/reclaimprotocol/.github/blob/main/Code-of-Conduct.md).
- [x] I have signed the [Contributor License Agreement (CLA)](https://github.com/reclaimprotocol/.github/blob/main/CLA.md).
- [x] I have considered the [Security Policy](https://github.com/reclaimprotocol/.github/blob/main/SECURITY.md).
- [x] I have self-reviewed and tested my code.
- [x] I have updated documentation as needed.
- [x] I agree to the [project's custom license](https://github.com/reclaimprotocol/.github/blob/main/LICENSE).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to show or hide the "Install Extension" button in the modal window.
* **Improvements**
  * Enhanced validation for modal configuration options to ensure correct data types and values.
* **Chores**
  * Updated package version to 4.2.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->