### PR TITLE
Fix: Update URL construction for Android instant app redirection

### DIFF
--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -730,8 +730,8 @@ export class ReclaimProofRequest {
             let template = encodeURIComponent(JSON.stringify(this.templateData));
             template = replaceAll(template, '(', '%28');
             template = replaceAll(template, ')', '%29');
-
-            const instantAppUrl = `https://share.reclaimprotocol.org/verify/?template=${template}`;
+            const url = `https://share.reclaimprotocol.org/verify/?template=${template}`;
+            const instantAppUrl = `intent://details?id=org.reclaimprotocol.app&launch=true&url=${url}&referrer=Z#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end;`;
             logger.info('Redirecting to Android instant app: ' + instantAppUrl);
 
             // Redirect to instant app


### PR DESCRIPTION
### Description
Fixed Android instant app redirect to use proper intent scheme for redirection. The previous implementation used a direct URL to the web verification page, but this change wraps it in an Android intent that will redirect users to instant app (also remove the open in browser app)

### Testing (ignore for documentation update)
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/59600383-b778-4afc-8efe-3be4faf0fc7b" />

### Type of change
- [x] Bug fix
- [] New feature
- [] Breaking change
- [] Documentation update

### Checklist:
- [x] I have read and agree to the [Code of Conduct](https://github.com/reclaimprotocol/.github/blob/main/Code-of-Conduct.md).
- [x] I have signed the [Contributor License Agreement (CLA)](https://github.com/reclaimprotocol/.github/blob/main/CLA.md).
- [x] I have considered the [Security Policy](https://github.com/reclaimprotocol/.github/blob/main/SECURITY.md).
- [x] I have self-reviewed and tested my code.
- [x] I have updated documentation as needed.
- [x] I agree to the [project's custom license](https://github.com/reclaimprotocol/.github/blob/main/LICENSE).

### Additional Notes:
If the device doesn't support instant app it will redirect to the playstore 