### PR TITLE
feat: support custom sharepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Install the Reclaim Protocol SDK and a QR code generator:
 npm install @reclaimprotocol/js-sdk react-qr-code
 ```
 
-**Current SDK Version**: 4.3.0
+**Current SDK Version**: 4.4.0
 
 ## Step 3: Set up your React component
 
@@ -354,7 +354,24 @@ The Reclaim SDK offers several advanced options to customize your integration:
    )
    ```
 
-7. **Platform-Specific Flow Control**:
+7. **Custom Share Page and App Clip URLs**:
+   You can customize the share page and app clip URLs for your app: 
+
+  ```javascript
+  const proofRequest = await ReclaimProofRequest.init(
+  APP_ID,
+  APP_SECRET,
+  PROVIDER_ID,
+  {
+    customSharePageUrl: 'https://your-custom-domain.com/verify', // Custom share page URL
+    customAppClipUrl: 'https://appclip.apple.com/id?p=your.custom.app.clip', // Custom iOS App Clip URL
+    // ... other options
+  }
+  )
+  ```
+
+
+8. **Platform-Specific Flow Control**:
    The `triggerReclaimFlow()` method provides intelligent platform detection, but you can still use traditional methods for custom flows:
    ```javascript
    // Traditional approach with manual QR code handling
@@ -366,7 +383,7 @@ The Reclaim SDK offers several advanced options to customize your integration:
    // Automatically handles platform detection and optimal user experience
    ```
 
-8. **Exporting and Importing SDK Configuration**:
+9. **Exporting and Importing SDK Configuration**:
    You can export the entire Reclaim SDK configuration as a JSON string and use it to initialize the SDK with the same configuration on a different service or backend:
    ```javascript
    // On the client-side or initial service
@@ -381,7 +398,7 @@ The Reclaim SDK offers several advanced options to customize your integration:
    ```
    This allows you to generate request URLs and other details from your backend or a different service while maintaining the same configuration.
 
-9. **Utility Methods**:
+10. **Utility Methods**:
    Additional utility methods for managing your proof requests:
    ```javascript
    // Get the current session ID

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reclaimprotocol/js-sdk",
-  "version": "4.3.5",
+  "version": "4.4.0",
   "description": "Designed to request proofs from the Reclaim protocol and manage the flow of claims and witness interactions.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reclaimprotocol/js-sdk",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "description": "Designed to request proofs from the Reclaim protocol and manage the flow of claims and witness interactions.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -553,7 +553,8 @@ export class ReclaimProofRequest {
                 // check if the app is running on iOS or Android
                 const isIos = getMobileDeviceType() === DeviceType.IOS;
                 if (!isIos) {
-                    const instantAppUrl = `https://share.reclaimprotocol.org/verify/?template=${template}`;
+                    // const instantAppUrl = `https://share.reclaimprotocol.org/verify/?template=${template}`;
+                    const instantAppUrl = `intent://details?id=org.reclaimprotocol.app&launch=true&template=${template}&referrer=Z#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end;`
                     logger.info('Instant App Url created successfully: ' + instantAppUrl);
                     return instantAppUrl;
                 } else {
@@ -698,7 +699,7 @@ export class ReclaimProofRequest {
             template = replaceAll(template, '(', '%28');
             template = replaceAll(template, ')', '%29');
 
-            const instantAppUrl = `https://share.reclaimprotocol.org/verify/?template=${template}`;
+            const instantAppUrl = `intent://details?id=org.reclaimprotocol.app&launch=true&template=${template}&referrer=Z#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end;`;
             logger.info('Redirecting to Android instant app: ' + instantAppUrl);
 
             // Redirect to instant app
@@ -770,7 +771,7 @@ export class ReclaimProofRequest {
                         }
                         // check if the proofs array has only one proof then send the proofs in onSuccess 
                         if (proofs.length === 1) {
-                            
+
                             onSuccess(proofs[0]);
                         } else {
                             onSuccess(proofs);

--- a/src/utils/proofUtils.ts
+++ b/src/utils/proofUtils.ts
@@ -48,7 +48,7 @@ export async function createLinkWithTemplateData(templateData: TemplateData, sha
   let template = encodeURIComponent(JSON.stringify(templateData))
   template = replaceAll(template, '(', '%28')
   template = replaceAll(template, ')', '%29')
-  const fullLink = sharePagePath ? `${sharePagePath}/?template=${template}` : `${constants.RECLAIM_SHARE_URL}/verifier/?template=${template}`
+  const fullLink = sharePagePath ? `${sharePagePath}/?template=${template}` : `${constants.RECLAIM_SHARE_URL}{template}`
   try {
     const shortenedLink = await getShortenedUrl(fullLink)
     return shortenedLink;

--- a/src/utils/proofUtils.ts
+++ b/src/utils/proofUtils.ts
@@ -48,7 +48,7 @@ export async function createLinkWithTemplateData(templateData: TemplateData, sha
   let template = encodeURIComponent(JSON.stringify(templateData))
   template = replaceAll(template, '(', '%28')
   template = replaceAll(template, ')', '%29')
-  const fullLink = sharePagePath ? `${sharePagePath}/?template=${template}` : `${constants.RECLAIM_SHARE_URL}{template}`
+  const fullLink = sharePagePath ? `${sharePagePath}/?template=${template}` : `${constants.RECLAIM_SHARE_URL}${template}`
   try {
     const shortenedLink = await getShortenedUrl(fullLink)
     return shortenedLink;

--- a/src/utils/proofUtils.ts
+++ b/src/utils/proofUtils.ts
@@ -41,14 +41,14 @@ export async function getShortenedUrl(url: string): Promise<string> {
 /**
  * Creates a link with embedded template data
  * @param templateData - The data to be embedded in the link
+ * @param sharePagePath - The path to the share page (optional)
  * @returns A promise that resolves to the created link (shortened if possible)
  */
-export async function createLinkWithTemplateData(templateData: TemplateData): Promise<string> {
+export async function createLinkWithTemplateData(templateData: TemplateData, sharePagePath?: string): Promise<string> {
   let template = encodeURIComponent(JSON.stringify(templateData))
   template = replaceAll(template, '(', '%28')
   template = replaceAll(template, ')', '%29')
-
-  const fullLink = `${constants.RECLAIM_SHARE_URL}${template}`
+  const fullLink = sharePagePath ? `${sharePagePath}/?template=${template}` : `${constants.RECLAIM_SHARE_URL}/verifier/?template=${template}`
   try {
     const shortenedLink = await getShortenedUrl(fullLink)
     return shortenedLink;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -37,6 +37,8 @@ export type ProofRequestOptions = {
   useBrowserExtension?: boolean;
   extensionID?: string;
   providerVersion?: string;
+  customSharePageUrl?: string;
+  customAppClipUrl?: string
 };
 
 // Modal customization options


### PR DESCRIPTION
### Description
Added comprehensive support for custom share page and app clip URLs in the Reclaim JS SDK. This enhancement allows developers to completely customize the verification flow URLs for branding, white-labeling, and multi-tenant applications while maintaining full backward compatibility.


### Testing (ignore for documentation update)
yes tested using different app link/share page 

### Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

### Checklist:
- [x] I have read and agree to the [Code of Conduct](https://github.com/reclaimprotocol/.github/blob/main/Code-of-Conduct.md).
- [x] I have signed the [Contributor License Agreement (CLA)](https://github.com/reclaimprotocol/.github/blob/main/CLA.md).
- [x] I have considered the [Security Policy](https://github.com/reclaimprotocol/.github/blob/main/SECURITY.md).
- [x] I have self-reviewed and tested my code.
- [x] I have updated documentation as needed.
- [x] I agree to the [project's custom license](https://github.com/reclaimprotocol/.github/blob/main/LICENSE).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added options to customize Share Page and App Clip URLs.
  - Introduced config export/import via toJsonString and fromJsonString.
  - Added methods to get the current session ID and check browser extension availability.
  - Streamlined request flows for web and mobile paths.

- Documentation
  - README updated with new init options, export/import examples, session ID usage, and revised step flow.

- Chores
  - Version bumped to 4.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->