### PR TITLE
fix(utils/errors): correct typo in error class name

### DIFF
--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -36,5 +36,5 @@ export const AddContextError = createErrorClass('AddContextError');
 export const SetSignatureError = createErrorClass('SetSignatureError');
 export const GetAppCallbackUrlError = createErrorClass("GetAppCallbackUrlError");
 export const StatusUrlError = createErrorClass('StatusUrlError');
-export const InavlidParametersError = createErrorClass('InavlidParametersError');
+export const InvalidParametersError = createErrorClass('InvalidParametersError');
 export const ProofSubmissionFailedError = createErrorClass('ProofSubmissionFailedError');


### PR DESCRIPTION
Fixed typo in src/utils/errors.ts:

Renamed InavlidParametersError → InvalidParametersError.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in a publicly exposed error name, changing “InavlidParametersError” to “InvalidParametersError.” This ensures accurate error identification, consistent messaging, and reliable error handling in integrations. Other error types are unaffected.

* **Refactor**
  * Aligned error naming for consistency across the codebase and surfaced API, improving developer experience without altering behavior or introducing new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->