### PR TITLE
Add verificationConfig parameter to startSession for customizing veri…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.0]
+
+### Added
+
+- Add `verificationConfig` parameter to `startSession` method.
+
 ## [5.0.1]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Let's break down what's happening in this code:
 
    - Generate a request URL using `getRequestUrl()`. This URL is used to create the QR code.
    - Get the status URL using `getStatusUrl()`. This URL can be used to check the status of the claim process.
-   - Start a session with `startSession()`, which sets up callbacks for successful and failed verifications.
+   - Start a session with `startSession()`, which sets up callbacks for successful and failed verifications, and allows you to pass an optional `verificationConfig` to customize proof verification.
 
 3. We display a QR code using the request URL. When a user scans this code, it starts the verification process.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reclaimprotocol/js-sdk",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "Designed to request proofs from the Reclaim protocol and manage the flow of claims and witness interactions.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -1671,6 +1671,7 @@ export class ReclaimProofRequest {
      *
      * @param onSuccess - Callback function invoked when proof is successfully submitted
      * @param onError - Callback function invoked when an error occurs during the session
+     * @param verificationConfig - Optional configuration to customize proof verification
      * @returns Promise<void>
      * @throws {SessionNotStartedError} When session ID is not defined
      * @throws {ProofNotVerifiedError} When proof verification fails (default callback only)
@@ -1689,7 +1690,7 @@ export class ReclaimProofRequest {
      * });
      * ```
      */
-    async startSession({ onSuccess, onError }: StartSessionParams): Promise<void> {
+    async startSession({ onSuccess, onError, verificationConfig }: StartSessionParams): Promise<void> {
         if (!this.sessionId) {
             const message = "Session can't be started due to undefined value of sessionId";
             logger.info(message);
@@ -1732,10 +1733,10 @@ export class ReclaimProofRequest {
                     if (statusUrlResponse.session.proofs && statusUrlResponse.session.proofs.length > 0) {
                         const proofs = statusUrlResponse.session.proofs;
                         if (this.claimCreationType === ClaimCreationType.STANDALONE) {
-                            const { isVerified: verified } = await verifyProof(proofs, this.getProviderVersion());
-                            if (!verified) {
+                            const result = await verifyProof(proofs, verificationConfig ?? this.getProviderVersion());
+                            if (!result.isVerified) {
                                 logger.info(`Proofs not verified: count=${proofs?.length}`);
-                                throw new ProofNotVerifiedError();
+                                throw new ProofNotVerifiedError(`Proofs not verified: count=${proofs?.length}`, result.error);
                             }
                         }
                         // check if the proofs array has only one proof then send the proofs in onSuccess

--- a/src/utils/__tests__/request.test.ts
+++ b/src/utils/__tests__/request.test.ts
@@ -563,4 +563,74 @@ describe('Request', () => {
             expect(output.options.launchOptions.verificationMode).toEqual('app');
         });
     });
+
+    describe('startSession', () => {
+        let originalSetInterval: typeof setInterval;
+        let originalClearInterval: typeof clearInterval;
+
+        beforeEach(() => {
+            originalSetInterval = global.setInterval;
+            originalClearInterval = global.clearInterval;
+        });
+
+        afterEach(() => {
+            global.setInterval = originalSetInterval;
+            global.clearInterval = originalClearInterval;
+        });
+
+        it('should accept and use verificationConfig in startSession without breaking the api', async () => {
+            let intervalCb: any;
+            (global as any).setInterval = (cb: any, time: number) => {
+                intervalCb = cb;
+                return 123 as any;
+            };
+            (global as any).clearInterval = () => {};
+
+            globalThis.fetch = mockFetchBy((url) => {
+                if (url.includes('session/')) {
+                    return {
+                        session: {
+                            statusV2: 'PROOF_GENERATION_SUCCESS',
+                            proofs: [{
+                                identifier: '0x123',
+                                claimData: {
+                                    provider: 'http',
+                                    parameters: '{}',
+                                    owner: '0x0',
+                                    timestampS: 1234567890,
+                                    context: 'some-context',
+                                    identifier: '0x123',
+                                    epoch: 1
+                                },
+                                signatures: ['0xinvalid'],
+                                witnesses: []
+                            }]
+                        },
+                        sessionId: '123',
+                        resolvedProviderVersion: '1.0.0'
+                    };
+                }
+                return { success: true };
+            });
+
+            const request = await ReclaimProofRequest.init(testAppId, testAppSecret, 'example');
+
+            const mockSuccess = jest.fn();
+            const mockError = jest.fn();
+
+            await request.startSession({
+                onSuccess: mockSuccess,
+                onError: mockError,
+                verificationConfig: { dangerouslyDisableContentValidation: true }
+            });
+
+            // Trigger the interval callback manually
+            await intervalCb();
+
+            expect(mockError).toHaveBeenCalled();
+            const err = mockError.mock.calls[0][0];
+            expect(err.message).toContain('Proofs not verified');
+            expect(mockSuccess).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,4 +1,5 @@
 import type { Context, Proof, ProviderClaimData, TeeAttestation } from './interfaces';
+import { VerificationConfig } from './proofValidationUtils';
 import { InjectedRequestSpec, InterceptorRequestSpec, ProviderHashRequirementsConfig, ReclaimProviderConfigWithRequestSpec, RequestSpec, ResponseMatchSpec, ResponseRedactionSpec } from './providerUtils';
 
 // Claim-related types
@@ -39,6 +40,7 @@ export type CreateVerificationRequest = {
 export type StartSessionParams = {
   onSuccess: OnSuccess;
   onError: OnError;
+  verificationConfig?: VerificationConfig;
 };
 
 export type OnSuccess = (proof?: Proof | Proof[]) => void;


### PR DESCRIPTION
…fication

### Description
<!-- Briefly describe the changes in this PR. -->

### Testing (ignore for documentation update)
<!-- Briefly describe how you've tested this implementation -->

### Type of change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

### Checklist:
- [x] I have read and agree to the [Code of Conduct](https://github.com/reclaimprotocol/.github/blob/main/Code-of-Conduct.md).
- [x] I have signed the [Contributor License Agreement (CLA)](https://github.com/reclaimprotocol/.github/blob/main/CLA.md).
- [x] I have considered the [Security Policy](https://github.com/reclaimprotocol/.github/blob/main/SECURITY.md).
- [x] I have self-reviewed and tested my code.
- [x] I have updated documentation as needed.
- [x] I agree to the [project's custom license](https://github.com/reclaimprotocol/.github/blob/main/LICENSE).

### Additional Notes:
<!-- Any other context about the PR. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `startSession` now accepts an optional configuration parameter, allowing customization of proof verification during session setup.

* **Tests**
  * Added test coverage for verification configuration functionality.

* **Documentation**
  * Updated documentation to describe the new verification configuration options available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->