### PR TITLE
refactor(tee): improve TEE attestation verification API design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.2.0]
+
+### Changed
+
+- **Breaking:** `verifyTeeAttestation` now takes `(proof, appSecret)` instead of `(proof)`. It performs full GCP attestation verification and returns `{ isVerified, error? }` instead of a boolean. The application ID is derived from `appSecret` automatically.
+- **Breaking:** `verifyProof` config option renamed from `verifyTEE: boolean` to `teeAttestation: { appSecret }`. The app secret is now required so the SDK can verify application binding and recompute the attestation nonce.
+
+### Added
+- GCP TEE attestation verification: OIDC token signature validation, platform claims, nonce/digest binding, application and session binding.
+- `isTeeVerified` field on `VerifyProofResult` (always a boolean).
+- `TeeVerificationError` exported for catching TEE-specific failures.
+
 ## [5.1.0]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -717,16 +717,16 @@ const proofRequest = await ReclaimProofRequest.init(APP_ID, APP_SECRET, PROVIDER
 
 ### Verifying TEE Attestation
 
-Set `verifyTEE: true` in the config to require and verify TEE attestation. If TEE data is missing or invalid, verification will fail with a `TeeVerificationError`.
+Provide a `teeAttestation` config to require and verify TEE attestation. If TEE data is missing or invalid, verification will fail with a `TeeVerificationError`.
 
 ```javascript
 import { verifyProof, TeeVerificationError } from "@reclaimprotocol/js-sdk";
 
-// Set verifyTEE in config to require TEE verification
 const { isVerified, isTeeVerified, data, error } = await verifyProof(proof, {
   hashes: ['0xAbC...'],
-  verifyTEE: true,
-  teeVerificationSecret: APP_SECRET,
+  teeAttestation: {
+    appSecret: APP_SECRET,
+  },
 });
 
 if (isVerified) {
@@ -740,26 +740,28 @@ if (isVerified) {
 }
 ```
 
-When `verifyTEE` is `true`, the result includes `isTeeVerified`. The overall `isVerified` will be `false` if TEE data is missing or TEE verification fails.
+The result always includes `isTeeVerified`. It is `true` only when `teeAttestation` was provided and verification passed; `false` otherwise. The overall `isVerified` will be `false` if TEE data is missing or TEE verification fails.
 
 The TEE verification validates:
 - **Nonce binding**: Ensures the attestation nonce matches the proof context
-- **Application ID**: Confirms the attestation was generated for your application (optional)
+- **Application ID**: Confirms the attestation was generated for your application
 - **Session and timestamp binding**: Verifies the nonce metadata matches the proof session and is within the allowed skew
-- **OIDC token signature**: Validates the Google Confidential Computing attestation JWT against Google's JWKS
+- **OIDC token signature**: Validates the Google Confidential Computing attestation JWT against Google's JWKS (cached for 5 minutes)
 - **Platform claims**: Confirms the expected GCP confidential-computing claims such as issuer, secure boot, hardware model, and GCE instance metadata
 - **Digest binding**: Confirms the workload and verifier image digests are present in the attestation token nonce list
 
-For hash-based attestation nonces, pass your **Application Secret** as `teeVerificationSecret` so the SDK can recompute the expected nonce locally.
+For hash-based attestation nonces, pass your **Application Secret** as `appSecret` so the SDK can recompute the expected nonce locally.
 
-You can also verify TEE attestation separately using the lower-level `verifyTeeAttestation` function:
+You can also verify TEE attestation separately using the standalone `verifyTeeAttestation` function:
 
 ```javascript
 import { verifyTeeAttestation } from "@reclaimprotocol/js-sdk";
 
-const isTeeValid = await verifyTeeAttestation(proof, APP_ID, APP_SECRET);
-if (isTeeValid) {
+const { isVerified, error } = await verifyTeeAttestation(proof, APP_ID, APP_SECRET);
+if (isVerified) {
   console.log("TEE attestation verified — proof was generated in a secure enclave");
+} else {
+  console.log("TEE verification failed:", error);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -703,7 +703,7 @@ const { isVerified } = await verifyProof(proof, {
 
 ## TEE Attestation Verification
 
-The SDK supports verifying TEE (Trusted Execution Environment) attestations included in proofs. The current attestation flow verifies the Google Confidential Computing OIDC token returned by Popcorn's GCP attestor and checks that it is bound to the proof nonce and image digests.
+The SDK supports verifying TEE (Trusted Execution Environment) attestations included in proofs. The attestation flow verifies the Google Confidential Computing OIDC token returned by Popcorn's GCP attestor and checks that it is bound to the proof nonce, application identity, and image digests.
 
 ### Enabling TEE Attestation
 
@@ -715,9 +715,9 @@ const proofRequest = await ReclaimProofRequest.init(APP_ID, APP_SECRET, PROVIDER
 });
 ```
 
-### Verifying TEE Attestation
+### Verifying TEE Attestation via `verifyProof`
 
-Provide a `teeAttestation` config to require and verify TEE attestation. If TEE data is missing or invalid, verification will fail with a `TeeVerificationError`.
+Provide a `teeAttestation` config to require and verify TEE attestation. The application ID is derived automatically from `appSecret`. If TEE data is missing or invalid, verification will fail with a `TeeVerificationError`.
 
 ```javascript
 import { verifyProof, TeeVerificationError } from "@reclaimprotocol/js-sdk";
@@ -730,8 +730,8 @@ const { isVerified, isTeeVerified, data, error } = await verifyProof(proof, {
 });
 
 if (isVerified) {
-  console.log("Proof is fully verified with hardware attestation");
-  console.log("TEE verified:", isTeeVerified);
+  console.log("Proof verified with hardware attestation");
+  console.log("TEE verified:", isTeeVerified); // always true when teeAttestation is provided and passes
   console.log("Extracted parameters:", data[0].extractedParameters);
 } else if (error instanceof TeeVerificationError) {
   console.log("TEE verification failed:", error.message);
@@ -740,57 +740,53 @@ if (isVerified) {
 }
 ```
 
-The result always includes `isTeeVerified`. It is `true` only when `teeAttestation` was provided and verification passed; `false` otherwise. The overall `isVerified` will be `false` if TEE data is missing or TEE verification fails.
+The result always includes `isTeeVerified` as a boolean. It is `true` only when `teeAttestation` was provided and verification passed; `false` otherwise.
 
-The TEE verification validates:
+### What TEE verification checks
+
+- **Application binding**: Derives the application ID from `appSecret` and confirms the attestation was generated for your application
 - **Nonce binding**: Ensures the attestation nonce matches the proof context
-- **Application ID**: Confirms the attestation was generated for your application
 - **Session and timestamp binding**: Verifies the nonce metadata matches the proof session and is within the allowed skew
-- **OIDC token signature**: Validates the Google Confidential Computing attestation JWT against Google's JWKS (cached for 5 minutes)
-- **Platform claims**: Confirms the expected GCP confidential-computing claims such as issuer, secure boot, hardware model, and GCE instance metadata
+- **OIDC token signature**: Validates the Google Confidential Computing attestation JWT against Google's JWKS (responses are cached for 5 minutes)
+- **Platform claims**: Confirms the expected GCP confidential-computing claims (issuer, secure boot, hardware model, GCE instance metadata)
 - **Digest binding**: Confirms the workload and verifier image digests are present in the attestation token nonce list
 
-For hash-based attestation nonces, pass your **Application Secret** as `appSecret` so the SDK can recompute the expected nonce locally.
+### Standalone `verifyTeeAttestation`
 
-You can also verify TEE attestation separately using the standalone `verifyTeeAttestation` function:
+You can verify TEE attestation for a single proof without running full proof verification:
 
 ```javascript
 import { verifyTeeAttestation } from "@reclaimprotocol/js-sdk";
 
-const { isVerified, error } = await verifyTeeAttestation(proof, APP_ID, APP_SECRET);
+const { isVerified, error } = await verifyTeeAttestation(proof, APP_SECRET);
 if (isVerified) {
-  console.log("TEE attestation verified — proof was generated in a secure enclave");
+  console.log("TEE attestation verified");
 } else {
   console.log("TEE verification failed:", error);
 }
 ```
 
+`appSecret` is your Reclaim application secret. The application ID is derived from it automatically.
+
 ### Browser vs Server Verification
 
-TEE verification validates the Google Confidential Computing attestation JWT by fetching Google's OIDC metadata and JWKS. In browser-only environments this may fail due to cross-origin restrictions when fetching Google's discovery endpoints.
+TEE verification fetches Google's OIDC metadata and JWKS endpoints. In browser-only environments this may fail due to cross-origin restrictions.
 
-For web apps, prefer verifying TEE attestations on the server:
+For web apps, verify TEE attestations on the server:
 
 ```javascript
-// POST your proof(s) to your server and verify there
 const response = await fetch('/api/verify-tee', {
   method: 'POST',
   headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify({
-    proofs,
-    expectedApplicationId: APP_ID,
-    applicationSecret: APP_SECRET,
-  }),
+  body: JSON.stringify({ proofs }),
 });
 
 const { results } = await response.json();
 console.log(results);
 ```
 
-The example app included in this repository now uses a server route for TEE verification:
+The server route should read the app secret from environment variables only (never accept it from the client request body). See the example app for a reference implementation:
 - `example/src/app/api/verify-tee/route.ts`
-
-That route returns per-proof TEE verification results and failure reasons so the UI can show why verification failed.
 
 ## Error Handling
 

--- a/example/src/app/api/verify-tee/route.ts
+++ b/example/src/app/api/verify-tee/route.ts
@@ -18,16 +18,11 @@ export async function POST(request: Request) {
       )
     }
 
-    const applicationId = process.env.RECLAIM_APP_ID || process.env.NEXT_PUBLIC_RECLAIM_APP_ID
     const appSecret = process.env.RECLAIM_APP_SECRET || process.env.NEXT_PUBLIC_RECLAIM_APP_SECRET
 
     const results = await Promise.all(
       proofs.map(async (proof, index) => {
-        const result = await verifyTeeAttestation(
-          proof,
-          applicationId,
-          appSecret
-        )
+        const result = await verifyTeeAttestation(proof, appSecret!)
 
         return {
           index,

--- a/example/src/app/api/verify-tee/route.ts
+++ b/example/src/app/api/verify-tee/route.ts
@@ -1,12 +1,9 @@
 import { NextResponse } from 'next/server'
-import { verifyTeeAttestationDetailed } from '@reclaimprotocol/js-sdk'
+import { verifyTeeAttestation } from '@reclaimprotocol/js-sdk'
 import type { Proof } from '@reclaimprotocol/js-sdk'
 
 type VerifyTeeRequestBody = {
   proofs?: Proof[]
-  expectedApplicationId?: string
-  applicationSecret?: string
-  teeVerificationSecret?: string
 }
 
 export async function POST(request: Request) {
@@ -21,27 +18,15 @@ export async function POST(request: Request) {
       )
     }
 
-    const expectedApplicationId =
-      body.expectedApplicationId ||
-      process.env.RECLAIM_APP_ID ||
-      process.env.NEXT_PUBLIC_RECLAIM_APP_ID
-
-    const applicationSecret =
-      body.applicationSecret ||
-      body.teeVerificationSecret ||
-      process.env.RECLAIM_APP_SECRET ||
-      process.env.NEXT_PUBLIC_RECLAIM_APP_SECRET
-
-    const teeVerificationSecret =
-      body.teeVerificationSecret ||
-      applicationSecret
+    const applicationId = process.env.RECLAIM_APP_ID || process.env.NEXT_PUBLIC_RECLAIM_APP_ID
+    const appSecret = process.env.RECLAIM_APP_SECRET || process.env.NEXT_PUBLIC_RECLAIM_APP_SECRET
 
     const results = await Promise.all(
       proofs.map(async (proof, index) => {
-        const result = await verifyTeeAttestationDetailed(
+        const result = await verifyTeeAttestation(
           proof,
-          expectedApplicationId,
-          teeVerificationSecret
+          applicationId,
+          appSecret
         )
 
         return {

--- a/example/src/app/page.tsx
+++ b/example/src/app/page.tsx
@@ -18,19 +18,12 @@ export default function Home() {
   const [reclaimProofRequest, setReclaimProofRequest] = useState<ReclaimProofRequest | null>(null)
   const [requestUrl, setRequestUrl] = useState<string | null>(null)
   const [proofJsonInput, setProofJsonInput] = useState('')
-  const [applicationSecretInput, setApplicationSecretInput] = useState(process.env.NEXT_PUBLIC_RECLAIM_APP_SECRET ?? '')
 
   async function verifyTeeOnServer(proofs: Proof[]): Promise<TeeCheckResult[]> {
     const response = await fetch('/api/verify-tee', {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        proofs,
-        expectedApplicationId: process.env.NEXT_PUBLIC_RECLAIM_APP_ID,
-        applicationSecret: applicationSecretInput.trim() || undefined,
-      }),
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ proofs }),
     })
 
     const payload = await response.json()
@@ -41,10 +34,10 @@ export default function Home() {
     return payload.results as TeeCheckResult[]
   }
 
-  async function runVerification(proofs: Proof[], options?: { strictProofConfig?: Parameters<typeof verifyProof>[1] }) {
+  async function runVerification(proofs: Proof[], proofConfig?: Parameters<typeof verifyProof>[1]) {
     const proofVerification = await verifyProof(
       proofs,
-      options?.strictProofConfig ?? { dangerouslyDisableContentValidation: true }
+      proofConfig ?? { dangerouslyDisableContentValidation: true }
     )
 
     const teeVerification = await verifyTeeOnServer(proofs)
@@ -69,14 +62,16 @@ export default function Home() {
         process.env.NEXT_PUBLIC_RECLAIM_PROVIDER_ID!,
         {
           log: true,
-          // acceptTeeAttestation: true,
+          acceptTeeAttestation: true,
+          canAutoSubmit: false
           // portalUrl: 'https://portal.reclaimprotocol.org', // default
           // launchOptions: { verificationMode: 'app' }, // for native app flow
           // useAppClip: true, // for App Clip on iOS with verificationMode: 'app'
           // portalUrl: 'https://portal.reclaimprotocol.org', 
         }
       )
-      proofRequest.setAppCallbackUrl('<YOUR_APP_CALLBACK_URL>', true)
+      //proofRequest.setAppCallbackUrl('https://webhooksite.net/cf05ecdb-2963-4555-83a4-61b24880d48a', true)
+      //proofRequest.setAppCallbackUrl('<YOUR_APP_CALLBACK_URL>', true)
       
 
       setReclaimProofRequest(proofRequest)
@@ -115,7 +110,7 @@ export default function Home() {
             setProofJsonInput(JSON.stringify(proofs, null, 2))
 
             const providerVersion = proofRequest.getProviderVersion()
-            await runVerification(proofs, { strictProofConfig: providerVersion })
+            await runVerification(proofs, providerVersion as Parameters<typeof verifyProof>[1])
           }
         },
         onError: (error: Error) => {
@@ -184,22 +179,6 @@ export default function Home() {
                 placeholder='Paste proof JSON here'
                 className="min-h-[240px] w-full rounded-lg border border-gray-300 p-3 font-mono text-sm text-gray-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
               />
-            </div>
-
-            <div>
-              <label className="mb-2 block text-sm font-medium text-gray-700">
-                Application Secret
-              </label>
-              <input
-                type="text"
-                value={applicationSecretInput}
-                onChange={(event) => setApplicationSecretInput(event.target.value)}
-                placeholder="Required for hash-based attestation nonces"
-                className="w-full rounded-lg border border-gray-300 p-3 text-sm text-gray-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-              />
-              <p className="mt-2 text-xs text-gray-500">
-                This should be your Reclaim application secret so the TEE nonce can be recomputed locally.
-              </p>
             </div>
 
             <div className="flex flex-col gap-3 sm:flex-row">

--- a/example/src/app/page.tsx
+++ b/example/src/app/page.tsx
@@ -70,7 +70,6 @@ export default function Home() {
         {
           log: true,
           // acceptTeeAttestation: true,
-          useAppClip: false,
           // portalUrl: 'https://portal.reclaimprotocol.org', // default
           // launchOptions: { verificationMode: 'app' }, // for native app flow
           // useAppClip: true, // for App Clip on iOS with verificationMode: 'app'
@@ -78,6 +77,8 @@ export default function Home() {
         }
       )
       proofRequest.setAppCallbackUrl('<YOUR_APP_CALLBACK_URL>', true)
+      
+
       setReclaimProofRequest(proofRequest)
       return proofRequest
     } catch (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reclaimprotocol/js-sdk",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@reclaimprotocol/js-sdk",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "license": "See License in <https://github.com/reclaimprotocol/.github/blob/main/LICENSE>",
       "dependencies": {
         "canonicalize": "^2.0.0",

--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -40,7 +40,6 @@ import {
     ErrorDuringVerificationError,
     CallbackUrlRequiredError,
     ProofNotValidatedError,
-    TeeVerificationError
 } from './utils/errors';
 import { validateContext, validateFunctionParams, validateParameters, validateSignature, validateURL, validateModalOptions, validateFunctionParamsWithFn, validateRedirectionMethod, validateRedirectionBody } from './utils/validationUtils'
 import { fetchStatusUrl, initSession, updateSession } from './utils/sessionUtils'
@@ -51,7 +50,7 @@ import { getDeviceType, getMobileDeviceType } from './utils/device'
 import { generateAttestationNonce } from './utils/attestationNonce'
 import { canonicalStringify } from './utils/strings'
 import { assertValidateProof, VerificationConfig } from './utils/proofValidationUtils'
-import { verifyTeeAttestation } from './utils/verifyTee'
+import { runTeeVerification } from './utils/verifyTee'
 import { fetchProviderHashRequirementsBy, ProviderHashRequirementsConfig } from './utils/providerUtils'
 
 const logger = loggerModule.logger
@@ -71,7 +70,7 @@ const sdkVersion = require('../package.json').version;
  *
  * @param proofOrProofs - A single proof object or an array of proof objects to be verified.
  * @param config - Verification configuration that specifies required hashes, allowed extra hashes, or disables content validation. Optionally includes `teeAttestation` to require TEE attestation verification.
- * @returns Verification result with `isVerified`, extracted `data` from each proof, optional `error` on failure, and `isTeeVerified` when `teeAttestation` is provided.
+ * @returns Verification result with `isVerified`, `isTeeVerified` (always boolean), extracted `data` from each proof, and optional `error` on failure. The application ID is derived from `appSecret` automatically.
  *
  * @example
  * ```typescript
@@ -140,44 +139,13 @@ export async function verifyProof(
 
         let isTeeVerified = false;
 
-        if (config.teeAttestation && 'dangerouslyDisableContentValidation' in config) {
+        if (config.teeAttestation && 'dangerouslyDisableContentValidation' in config && config.dangerouslyDisableContentValidation) {
             logger.warn('teeAttestation is enabled but content validation is disabled — TEE attestation alone does not guarantee proof contents are valid');
         }
 
         if (config.teeAttestation) {
-            const hasTeeData = proofs.every(proof => {
-                if (proof.teeAttestation) return true;
-                try {
-                    const context = JSON.parse(proof.claimData.context);
-                    return !!context?.attestationNonce;
-                } catch {
-                    return false;
-                }
-            });
-
-            if (!hasTeeData) {
-                const teeError = new TeeVerificationError('TEE verification requested but one or more proofs are missing TEE attestation data');
-                logger.error(teeError.message);
-                return createVerifyProofResultFailure(teeError, false);
-            }
-
-            try {
-                const { appSecret } = config.teeAttestation;
-                const appId = new ethers.Wallet(appSecret).address;
-                const teeResults = await Promise.all(
-                    proofs.map(proof => verifyTeeAttestation(proof, appId, appSecret))
-                );
-                isTeeVerified = teeResults.every(r => r.isVerified);
-                if (!isTeeVerified) {
-                    const teeError = new TeeVerificationError('TEE attestation verification failed for one or more proofs');
-                    logger.error(teeError.message);
-                    return createVerifyProofResultFailure(teeError, false);
-                }
-            } catch (error) {
-                const teeError = new TeeVerificationError('Error verifying TEE attestation', error);
-                logger.error(teeError.message);
-                return createVerifyProofResultFailure(teeError, false);
-            }
+            await runTeeVerification(proofs, config.teeAttestation);
+            isTeeVerified = true;
         }
 
         return createVerifyProofResultSuccess(proofs, isTeeVerified);

--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -70,8 +70,8 @@ const sdkVersion = require('../package.json').version;
  * * All 3 functions above are alternatives of each other and result from these functions can be directly used as `config` parameter in this function for proof validation.
  *
  * @param proofOrProofs - A single proof object or an array of proof objects to be verified.
- * @param config - Verification configuration that specifies required hashes, allowed extra hashes, or disables content validation. Optionally includes `verifyTEE` to require TEE attestation verification.
- * @returns Verification result with `isVerified`, extracted `data` from each proof, optional `error` on failure, and `isTeeVerified` when `verifyTEE` is enabled.
+ * @param config - Verification configuration that specifies required hashes, allowed extra hashes, or disables content validation. Optionally includes `teeAttestation` to require TEE attestation verification.
+ * @returns Verification result with `isVerified`, extracted `data` from each proof, optional `error` on failure, and `isTeeVerified` when `teeAttestation` is provided.
  *
  * @example
  * ```typescript
@@ -79,7 +79,7 @@ const sdkVersion = require('../package.json').version;
  * const { isVerified, data } = await verifyProof(proof, request.getProviderVersion());
  *
  * // With TEE attestation verification (fails if TEE data is missing or invalid)
- * const { isVerified, isTeeVerified, data } = await verifyProof(proof, { ...request.getProviderVersion(), verifyTEE: true });
+ * const { isVerified, isTeeVerified, data } = await verifyProof(proof, { ...request.getProviderVersion(), teeAttestation: { appSecret: APP_SECRET } });
  * 
  * // Or, by manually providing the details:
  * 
@@ -138,10 +138,22 @@ export async function verifyProof(
 
         await assertValidateProof(proofs, config);
 
-        let isTeeVerified: boolean | undefined = undefined;
+        let isTeeVerified = false;
 
-        if (config.verifyTEE) {
-            const hasTeeData = proofs.every(proof => proof.teeAttestation || JSON.parse(proof.claimData.context).attestationNonce);
+        if (config.teeAttestation && 'dangerouslyDisableContentValidation' in config) {
+            logger.warn('teeAttestation is enabled but content validation is disabled — TEE attestation alone does not guarantee proof contents are valid');
+        }
+
+        if (config.teeAttestation) {
+            const hasTeeData = proofs.every(proof => {
+                if (proof.teeAttestation) return true;
+                try {
+                    const context = JSON.parse(proof.claimData.context);
+                    return !!context?.attestationNonce;
+                } catch {
+                    return false;
+                }
+            });
 
             if (!hasTeeData) {
                 const teeError = new TeeVerificationError('TEE verification requested but one or more proofs are missing TEE attestation data');
@@ -150,10 +162,12 @@ export async function verifyProof(
             }
 
             try {
+                const { appSecret } = config.teeAttestation;
+                const appId = new ethers.Wallet(appSecret).address;
                 const teeResults = await Promise.all(
-                    proofs.map(proof => verifyTeeAttestation(proof, undefined, config.teeVerificationSecret))
+                    proofs.map(proof => verifyTeeAttestation(proof, appId, appSecret))
                 );
-                isTeeVerified = teeResults.every(r => r === true);
+                isTeeVerified = teeResults.every(r => r.isVerified);
                 if (!isTeeVerified) {
                     const teeError = new TeeVerificationError('TEE attestation verification failed for one or more proofs');
                     logger.error(teeError.message);

--- a/src/__tests__/verify_proof.test.ts
+++ b/src/__tests__/verify_proof.test.ts
@@ -12,7 +12,8 @@ import { ATTESTATION_NONCE_DOMAIN, generateAttestationNonce } from '../utils/att
 const GCP_ISSUER = 'https://confidentialcomputing.googleapis.com';
 const GCP_OIDC_URL = `${GCP_ISSUER}/.well-known/openid-configuration`;
 const GCP_JWKS_URL = `${GCP_ISSUER}/jwks`;
-const TEST_TEE_SECRET = 'test-app-secret';
+const TEST_TEE_SECRET = '0x49becaaf6bfe2472943302c64b7b2b6295a0ca5e28481bb6dc7c075d4dd50f82';
+const TEST_APP_SECRET = TEST_TEE_SECRET;
 const expectedApplicationId = '0xd116D518eacea61C7af9760E5d8D1b720a0CE8D5';
 const workloadDigest = 'us-docker.pkg.dev/rc-popcorn/popcorn-images/browser-node@sha256:97d4656f457831cf540b80a85daac40dcfa2f618beffcf3dd5966023ad8cab14';
 const verifierDigest = 'us-docker.pkg.dev/rc-popcorn/popcorn-images/attestor@sha256:acaa00688de4ce0517303172fc89efd085c6e1a9647ca50066353eba6b8cc228';
@@ -211,9 +212,17 @@ describe('verifyProof', () => {
         const proof = cloneProof();
         const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true });
         expect(result.isVerified).toBe(true);
+        expect(result.isTeeVerified).toBe(false);
         expect(result.error).toBeUndefined();
         expect(result.data).toHaveLength(1);
         expect(result.data[0].extractedParameters).toEqual({ DYNAMIC_GEO: 'IN', username: 'srivatsanqb' });
+    });
+
+    it('returns isTeeVerified as false when teeAttestation is not requested', async () => {
+        const proof = cloneProof();
+        const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true });
+        expect(result.isVerified).toBe(true);
+        expect(result.isTeeVerified).toBe(false);
     });
 
     it('returns error object when signature verification fails', async () => {
@@ -221,6 +230,7 @@ describe('verifyProof', () => {
         proof.signatures = ['0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ff'];
         const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true });
         expect(result.isVerified).toBe(false);
+        expect(result.isTeeVerified).toBe(false);
         expect(result.error).toBeInstanceOf(Error);
         expect(result.data).toEqual([]);
     });
@@ -230,6 +240,7 @@ describe('verifyProof', () => {
         proof.claimData.timestampS = proof.claimData.timestampS + 60 * 60;
         const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true });
         expect(result.isVerified).toBe(false);
+        expect(result.isTeeVerified).toBe(false);
         expect(result.error).toBeInstanceOf(Error);
         expect(result.data).toEqual([]);
     });
@@ -239,7 +250,7 @@ describe('verifyProof', () => {
         const attestation = attachLegacyNonceTeeAttestation(proof);
         attestation.workload.image_digest = `us-docker.pkg.dev/rc-popcorn/popcorn-images/browser-node@sha256:${'1'.repeat(64)}`;
 
-        const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true, verifyTEE: true });
+        const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true, teeAttestation: { appSecret: TEST_APP_SECRET } });
         expect(result.isVerified).toBe(false);
         expect(result.isTeeVerified).toBe(false);
         expect(result.error).toBeInstanceOf(TeeVerificationError);
@@ -249,7 +260,7 @@ describe('verifyProof', () => {
         const proof = cloneProof();
         delete (proof as any).teeAttestation;
 
-        const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true, verifyTEE: true });
+        const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true, teeAttestation: { appSecret: TEST_APP_SECRET } });
         expect(result.isVerified).toBe(false);
         expect(result.isTeeVerified).toBe(false);
         expect(result.error).toBeInstanceOf(TeeVerificationError);
@@ -260,30 +271,36 @@ describe('verifyProof', () => {
         const attestation = attachLegacyNonceTeeAttestation(proof);
         attestation.workload.image_digest = `us-docker.pkg.dev/rc-popcorn/popcorn-images/browser-node@sha256:${'2'.repeat(64)}`;
 
-        await expect(verifyTeeAttestation(proof, expectedApplicationId)).resolves.toBe(false);
+        const result = await verifyTeeAttestation(proof, expectedApplicationId);
+        expect(result.isVerified).toBe(false);
+        expect(typeof result.error).toBe('string');
     });
 
     it('verifies a valid GCP TEE attestation when the hash-based nonce secret is provided', async () => {
         const proof = cloneProof();
         attachHashNonceTeeAttestation(proof);
 
-        await expect(
-            verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET)
-        ).resolves.toBe(true);
+        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        expect(result.isVerified).toBe(true);
+        expect(result.error).toBeUndefined();
     });
 
     it('fails hash-based nonce verification when the verifier does not provide the app secret', async () => {
         const proof = cloneProof();
         attachHashNonceTeeAttestation(proof);
 
-        await expect(verifyTeeAttestation(proof, expectedApplicationId)).resolves.toBe(false);
+        const result = await verifyTeeAttestation(proof, expectedApplicationId);
+        expect(result.isVerified).toBe(false);
+        expect(typeof result.error).toBe('string');
     });
 
     it('fails hash-based nonce verification when the verifier provides the wrong app secret', async () => {
         const proof = cloneProof();
         attachHashNonceTeeAttestation(proof);
 
-        await expect(verifyTeeAttestation(proof, expectedApplicationId, 'wrong-secret')).resolves.toBe(false);
+        const result = await verifyTeeAttestation(proof, expectedApplicationId, 'wrong-secret');
+        expect(result.isVerified).toBe(false);
+        expect(typeof result.error).toBe('string');
     });
 
     it('fails when the nonce is valid but generated for a different session', async () => {
@@ -304,9 +321,82 @@ describe('verifyProof', () => {
         proof.claimData.context = JSON.stringify(context);
         proof.teeAttestation = createGcpTeeAttestation(differentSessionNonce);
 
-        await expect(
-            verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET)
-        ).resolves.toBe(false);
+        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        expect(result.isVerified).toBe(false);
+        expect(typeof result.error).toBe('string');
+    });
+
+    it('caches JWKS keys across multiple verifyTeeAttestation calls', async () => {
+        const fetchSpy = global.fetch as jest.Mock;
+
+        // First call may or may not fetch (cache may be warm from earlier tests).
+        // Record the count before our two calls.
+        const proof1 = cloneProof();
+        attachHashNonceTeeAttestation(proof1);
+        const proof2 = cloneProof();
+        attachHashNonceTeeAttestation(proof2);
+
+        await verifyTeeAttestation(proof1, expectedApplicationId, TEST_TEE_SECRET);
+        const countAfterFirst = fetchSpy.mock.calls.length;
+
+        await verifyTeeAttestation(proof2, expectedApplicationId, TEST_TEE_SECRET);
+        const countAfterSecond = fetchSpy.mock.calls.length;
+
+        // Second call should not make any additional JWKS/OIDC fetches
+        expect(countAfterSecond).toBe(countAfterFirst);
+    });
+
+    it('returns error when proof context is malformed JSON', async () => {
+        const proof = cloneProof();
+        attachHashNonceTeeAttestation(proof);
+        proof.claimData.context = 'not-valid-json{{{';
+
+        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        expect(result.isVerified).toBe(false);
+        expect(result.error).toContain('Malformed proof');
+    });
+
+    it('returns error when proof context is missing attestationNonce', async () => {
+        const proof = cloneProof();
+        attachHashNonceTeeAttestation(proof);
+        const context = JSON.parse(proof.claimData.context);
+        delete context.attestationNonce;
+        proof.claimData.context = JSON.stringify(context);
+
+        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        expect(result.isVerified).toBe(false);
+        expect(result.error).toContain('attestationNonce');
+    });
+
+    it('returns error when proof context is missing attestationNonceData', async () => {
+        const proof = cloneProof();
+        attachHashNonceTeeAttestation(proof);
+        const context = JSON.parse(proof.claimData.context);
+        delete context.attestationNonceData;
+        proof.claimData.context = JSON.stringify(context);
+
+        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        expect(result.isVerified).toBe(false);
+        expect(result.error).toContain('attestationNonceData');
+    });
+
+    it('handles teeAttestation as a JSON string on the proof', async () => {
+        const proof = cloneProof();
+        const tee = attachHashNonceTeeAttestation(proof);
+        proof.teeAttestation = JSON.stringify(tee) as any;
+
+        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        expect(result.isVerified).toBe(true);
+    });
+
+    it('returns error when teeAttestation is missing from proof', async () => {
+        const proof = cloneProof();
+        attachHashNonceTeeAttestation(proof);
+        delete (proof as any).teeAttestation;
+
+        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        expect(result.isVerified).toBe(false);
+        expect(result.error).toContain('Missing teeAttestation');
     });
 
     it('throws immediately when TEE verification is invoked in a browser-like environment', async () => {

--- a/src/__tests__/verify_proof.test.ts
+++ b/src/__tests__/verify_proof.test.ts
@@ -141,6 +141,10 @@ function attachLegacyNonceTeeAttestation(proof: Proof): TeeAttestation {
 
 function attachHashNonceTeeAttestation(proof: Proof, secret = TEST_TEE_SECRET): TeeAttestation {
     const context = JSON.parse(proof.claimData.context);
+    // Derive appId from the secret and update the context to match,
+    // so verifyTeeAttestation(proof, secret) can verify the binding.
+    const derivedAppId = new ethers.Wallet(secret).address;
+    context.attestationNonceData.applicationId = derivedAppId;
     const { applicationId, sessionId, timestamp } = context.attestationNonceData;
     const attestationNonce = generateAttestationNonce(secret, applicationId, sessionId, timestamp);
 
@@ -271,7 +275,7 @@ describe('verifyProof', () => {
         const attestation = attachLegacyNonceTeeAttestation(proof);
         attestation.workload.image_digest = `us-docker.pkg.dev/rc-popcorn/popcorn-images/browser-node@sha256:${'2'.repeat(64)}`;
 
-        const result = await verifyTeeAttestation(proof, expectedApplicationId);
+        const result = await verifyTeeAttestation(proof, TEST_TEE_SECRET);
         expect(result.isVerified).toBe(false);
         expect(typeof result.error).toBe('string');
     });
@@ -280,25 +284,18 @@ describe('verifyProof', () => {
         const proof = cloneProof();
         attachHashNonceTeeAttestation(proof);
 
-        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        const result = await verifyTeeAttestation(proof, TEST_TEE_SECRET);
         expect(result.isVerified).toBe(true);
         expect(result.error).toBeUndefined();
     });
 
-    it('fails hash-based nonce verification when the verifier does not provide the app secret', async () => {
+    it('fails verification when the wrong app secret is provided', async () => {
         const proof = cloneProof();
         attachHashNonceTeeAttestation(proof);
 
-        const result = await verifyTeeAttestation(proof, expectedApplicationId);
-        expect(result.isVerified).toBe(false);
-        expect(typeof result.error).toBe('string');
-    });
-
-    it('fails hash-based nonce verification when the verifier provides the wrong app secret', async () => {
-        const proof = cloneProof();
-        attachHashNonceTeeAttestation(proof);
-
-        const result = await verifyTeeAttestation(proof, expectedApplicationId, 'wrong-secret');
+        // A valid private key that doesn't match the proof's application
+        const wrongSecret = '0x1111111111111111111111111111111111111111111111111111111111111111';
+        const result = await verifyTeeAttestation(proof, wrongSecret);
         expect(result.isVerified).toBe(false);
         expect(typeof result.error).toBe('string');
     });
@@ -321,7 +318,7 @@ describe('verifyProof', () => {
         proof.claimData.context = JSON.stringify(context);
         proof.teeAttestation = createGcpTeeAttestation(differentSessionNonce);
 
-        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        const result = await verifyTeeAttestation(proof, TEST_TEE_SECRET);
         expect(result.isVerified).toBe(false);
         expect(typeof result.error).toBe('string');
     });
@@ -336,10 +333,10 @@ describe('verifyProof', () => {
         const proof2 = cloneProof();
         attachHashNonceTeeAttestation(proof2);
 
-        await verifyTeeAttestation(proof1, expectedApplicationId, TEST_TEE_SECRET);
+        await verifyTeeAttestation(proof1, TEST_TEE_SECRET);
         const countAfterFirst = fetchSpy.mock.calls.length;
 
-        await verifyTeeAttestation(proof2, expectedApplicationId, TEST_TEE_SECRET);
+        await verifyTeeAttestation(proof2, TEST_TEE_SECRET);
         const countAfterSecond = fetchSpy.mock.calls.length;
 
         // Second call should not make any additional JWKS/OIDC fetches
@@ -351,7 +348,7 @@ describe('verifyProof', () => {
         attachHashNonceTeeAttestation(proof);
         proof.claimData.context = 'not-valid-json{{{';
 
-        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        const result = await verifyTeeAttestation(proof, TEST_TEE_SECRET);
         expect(result.isVerified).toBe(false);
         expect(result.error).toContain('Malformed proof');
     });
@@ -363,7 +360,7 @@ describe('verifyProof', () => {
         delete context.attestationNonce;
         proof.claimData.context = JSON.stringify(context);
 
-        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        const result = await verifyTeeAttestation(proof, TEST_TEE_SECRET);
         expect(result.isVerified).toBe(false);
         expect(result.error).toContain('attestationNonce');
     });
@@ -375,7 +372,7 @@ describe('verifyProof', () => {
         delete context.attestationNonceData;
         proof.claimData.context = JSON.stringify(context);
 
-        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        const result = await verifyTeeAttestation(proof, TEST_TEE_SECRET);
         expect(result.isVerified).toBe(false);
         expect(result.error).toContain('attestationNonceData');
     });
@@ -385,7 +382,7 @@ describe('verifyProof', () => {
         const tee = attachHashNonceTeeAttestation(proof);
         proof.teeAttestation = JSON.stringify(tee) as any;
 
-        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        const result = await verifyTeeAttestation(proof, TEST_TEE_SECRET);
         expect(result.isVerified).toBe(true);
     });
 
@@ -394,7 +391,7 @@ describe('verifyProof', () => {
         attachHashNonceTeeAttestation(proof);
         delete (proof as any).teeAttestation;
 
-        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        const result = await verifyTeeAttestation(proof, TEST_TEE_SECRET);
         expect(result.isVerified).toBe(false);
         expect(result.error).toContain('Missing teeAttestation');
     });
@@ -411,7 +408,7 @@ describe('verifyProof', () => {
             (globalThis as any).document = {};
 
             await expect(
-                verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET)
+                verifyTeeAttestation(proof, TEST_TEE_SECRET)
             ).rejects.toThrow(
                 'TEE attestation verification is only supported in non-browser environments'
             );

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,8 @@ export * from './utils/sessionUtils';
 export type * from './utils/sessionUtils';
 export * from './witness';
 export type * from './witness';
-export { verifyTeeAttestation, verifyTeeAttestationDetailed } from './utils/verifyTee';
+export { verifyTeeAttestation } from './utils/verifyTee';
+export type { TeeVerificationResult } from './utils/verifyTee';
 export { TeeVerificationError } from './utils/errors';
 // Export device detection utilities for debugging (optional)
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export * from './utils/sessionUtils';
 export type * from './utils/sessionUtils';
 export * from './witness';
 export type * from './witness';
-export { verifyTeeAttestation } from './utils/verifyTee';
+export { verifyTeeAttestation, runTeeVerification } from './utils/verifyTee';
 export type { TeeVerificationResult } from './utils/verifyTee';
 export { TeeVerificationError } from './utils/errors';
 // Export device detection utilities for debugging (optional)

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -50,10 +50,10 @@ export function scheduleIntervalEndingTask(
   }, timeout)
 }
 
-export const createVerifyProofResultSuccess = (proofs: Proof[], isTeeVerified?: true): VerifyProofResultSuccess => {
+export const createVerifyProofResultSuccess = (proofs: Proof[], isTeeVerified = false): VerifyProofResultSuccess => {
   return {
     isVerified: true,
-    isTeeVerified: isTeeVerified,
+    isTeeVerified,
     error: undefined,
     data: proofs.map(createTrustedDataFromProofData),
     publicData: getPublicDataFromProofs(proofs),
@@ -61,11 +61,11 @@ export const createVerifyProofResultSuccess = (proofs: Proof[], isTeeVerified?: 
 }
 
 
-export const createVerifyProofResultFailure = (error: Error, isTeeVerified?: false): VerifyProofResultFailure => {
+export const createVerifyProofResultFailure = (error: Error, isTeeVerified = false): VerifyProofResultFailure => {
   return {
     isVerified: false,
-    isTeeVerified: isTeeVerified,
-    error: error,
+    isTeeVerified,
+    error,
     data: [],
     publicData: [],
   }

--- a/src/utils/proofValidationUtils.ts
+++ b/src/utils/proofValidationUtils.ts
@@ -73,18 +73,23 @@ export type ValidationConfig = ValidationConfigWithHash | ValidationConfigWithPr
  * Describes the comprehensive configuration required to initialize the proof verification process.
  * Aligns with `ValidationConfig` options for verifying signatures alongside proof contents.
  */
+export type TeeAttestationConfig = {
+    /**
+     * Your application secret (Ethereum private key).
+     * Used to recompute the TEE attestation nonce and to derive the application ID
+     * for binding the attestation to your application.
+     */
+    appSecret: string;
+};
+
 export type VerificationConfig = ValidationConfig & {
     /**
-     * If true, verifies TEE (Trusted Execution Environment) attestation included in the proof.
-     * When enabled, the result will include `isTeeVerified` and `isVerified` will be false
-     * if TEE data is missing or TEE verification fails.
+     * TEE attestation verification configuration.
+     * When provided, verifies the TEE attestation included in the proof.
+     * The result will include `isTeeVerified` and `isVerified` will be false
+     * if TEE attestation data is missing or verification fails.
      */
-    verifyTEE?: boolean;
-    /**
-     * Application secret used to recompute hash-based TEE attestation nonces.
-     * Required for verifying newer hash-based attestation nonces.
-     */
-    teeVerificationSecret?: string;
+    teeAttestation?: TeeAttestationConfig;
 };
 
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -344,7 +344,7 @@ export type TrustedData = {
 
 export type VerifyProofResultSuccess = {
   isVerified: true;
-  isTeeVerified?: boolean;
+  isTeeVerified: boolean;
   error: undefined;
   data: TrustedData[];
   publicData: any[];
@@ -352,7 +352,7 @@ export type VerifyProofResultSuccess = {
 
 export type VerifyProofResultFailure = {
   isVerified: false;
-  isTeeVerified?: boolean;
+  isTeeVerified: boolean;
   error: Error;
   data: [];
   publicData: [];

--- a/src/utils/verifyTee.ts
+++ b/src/utils/verifyTee.ts
@@ -149,16 +149,29 @@ async function sha256Hex(input: string): Promise<string> {
     return Array.from(new Uint8Array(digest), (value) => value.toString(16).padStart(2, '0')).join('');
 }
 
+const JWKS_CACHE_TTL_MS = 5 * 60 * 1000;
+let cachedJwksUri: string | null = null;
+let cachedJwksKeys: JsonWebKeyLike[] | null = null;
+let cachedJwksAt = 0;
+
 async function verifyJwtSignature(token: string, issuer: string): Promise<Record<string, any>> {
     const { header, payload, signingInput, signature } = decodeJwt(token);
     assert(header.alg === 'RS256', `unexpected attestation signing algorithm: ${header.alg}`);
     assert(typeof header.kid === 'string' && header.kid.length > 0, 'attestation token kid is missing');
 
-    const oidc = await fetchJson(`${issuer}/.well-known/openid-configuration`);
-    assert(typeof oidc?.jwks_uri === 'string' && oidc.jwks_uri.length > 0, 'issuer JWKS URI is missing');
+    const isCacheFresh = cachedJwksKeys && (Date.now() - cachedJwksAt) < JWKS_CACHE_TTL_MS;
 
-    const jwks = await fetchJson(oidc.jwks_uri);
-    const jwk = (jwks?.keys || []).find((key: JsonWebKeyLike) => key.kid === header.kid) as JsonWebKeyLike | undefined;
+    if (!isCacheFresh) {
+        const oidc = await fetchJson(`${issuer}/.well-known/openid-configuration`);
+        assert(typeof oidc?.jwks_uri === 'string' && oidc.jwks_uri.length > 0, 'issuer JWKS URI is missing');
+        cachedJwksUri = oidc.jwks_uri;
+
+        const jwks = await fetchJson(cachedJwksUri!);
+        cachedJwksKeys = jwks?.keys || [];
+        cachedJwksAt = Date.now();
+    }
+
+    const jwk = cachedJwksKeys!.find((key: JsonWebKeyLike) => key.kid === header.kid) as JsonWebKeyLike | undefined;
     assert(jwk, `no JWKS key found for kid ${header.kid}`);
 
     const cryptoKey = await getSubtleCrypto().importKey(
@@ -180,23 +193,34 @@ async function verifyJwtSignature(token: string, issuer: string): Promise<Record
     return payload;
 }
 
-function parseProofContext(proof: Proof): { parsedContext: any; nonceDataObj: NonceContextData; expectedNonce: string } {
-    let parsedContext: any;
+function isNonceContextData(obj: unknown): obj is NonceContextData {
+    if (!obj || typeof obj !== 'object') return false;
+    const o = obj as Record<string, unknown>;
+    return typeof o.applicationId === 'string' && o.applicationId.length > 0
+        && typeof o.sessionId === 'string' && o.sessionId.length > 0
+        && typeof o.timestamp === 'string' && o.timestamp.length > 0;
+}
+
+function parseProofContext(proof: Proof): { parsedContext: Record<string, unknown>; nonceDataObj: NonceContextData; expectedNonce: string } {
+    let parsedContext: unknown;
     try {
         parsedContext = JSON.parse(proof.claimData.context);
     } catch {
-        throw new Error('Failed to parse proof context to extract attestationNonce');
+        throw new Error('Malformed proof: claimData.context is not valid JSON');
     }
 
-    const expectedNonce = parsedContext?.attestationNonce;
-    const nonceDataObj = parsedContext?.attestationNonceData as NonceContextData | undefined;
-    assert(expectedNonce, 'Proof context is missing attestationNonce or attestationNonceData');
-    assert(nonceDataObj, 'Proof context is missing attestationNonce or attestationNonceData');
-    assert(typeof nonceDataObj.applicationId === 'string' && nonceDataObj.applicationId.length > 0, 'Proof context attestationNonceData.applicationId is missing');
-    assert(typeof nonceDataObj.sessionId === 'string' && nonceDataObj.sessionId.length > 0, 'Proof context attestationNonceData.sessionId is missing');
-    assert(typeof nonceDataObj.timestamp === 'string' && nonceDataObj.timestamp.length > 0, 'Proof context attestationNonceData.timestamp is missing');
+    if (!parsedContext || typeof parsedContext !== 'object') {
+        throw new Error('Malformed proof: claimData.context is not a JSON object');
+    }
 
-    return { parsedContext, nonceDataObj, expectedNonce };
+    const ctx = parsedContext as Record<string, unknown>;
+    const expectedNonce = ctx.attestationNonce;
+    assert(typeof expectedNonce === 'string' && expectedNonce.length > 0, 'Proof context is missing attestationNonce');
+
+    const nonceDataObj = ctx.attestationNonceData;
+    assert(isNonceContextData(nonceDataObj), 'Proof context is missing or has invalid attestationNonceData (requires applicationId, sessionId, timestamp)');
+
+    return { parsedContext: ctx, nonceDataObj, expectedNonce };
 }
 
 function verifyApplicationAndSessionBinding(
@@ -214,11 +238,14 @@ function verifyApplicationAndSessionBinding(
         );
     }
 
-    let parsedParameters: any = {};
-    try {
-        parsedParameters = proof.claimData.parameters ? JSON.parse(proof.claimData.parameters) : {};
-    } catch {
-        parsedParameters = {};
+    let parsedParameters: Record<string, unknown> = {};
+    if (proof.claimData.parameters) {
+        try {
+            const parsed = JSON.parse(proof.claimData.parameters);
+            parsedParameters = (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) ? parsed : {};
+        } catch {
+            throw new Error('Malformed proof: claimData.parameters is not valid JSON');
+        }
     }
 
     const contextSessionId = parsedContext?.reclaimSessionId;
@@ -345,9 +372,9 @@ async function verifyGcpClaims(teeAttestation: TeeAttestation, expectedNonce: st
 
 /**
  * Validates the hardware TEE attestation included in the proof.
- * Throws an error if the attestation is invalid or compromised.
+ * Returns a result object with `isVerified` and an optional `error` message.
  */
-export async function verifyTeeAttestationDetailed(
+export async function verifyTeeAttestation(
     proof: Proof,
     expectedApplicationId?: string,
     expectedAppSecret?: string
@@ -386,14 +413,4 @@ export async function verifyTeeAttestationDetailed(
             error: error instanceof Error ? error.message : String(error),
         };
     }
-}
-
-export async function verifyTeeAttestation(
-    proof: Proof,
-    expectedApplicationId?: string,
-    expectedAppSecret?: string
-): Promise<boolean> {
-    assertNonBrowserEnvironment();
-    const result = await verifyTeeAttestationDetailed(proof, expectedApplicationId, expectedAppSecret);
-    return result.isVerified;
 }

--- a/src/utils/verifyTee.ts
+++ b/src/utils/verifyTee.ts
@@ -1,6 +1,8 @@
 import { Proof, TeeAttestation } from './interfaces';
 import { ethers } from 'ethers';
 import { generateAttestationNonce } from './attestationNonce';
+import { TeeVerificationError } from './errors';
+import type { TeeAttestationConfig } from './proofValidationUtils';
 import loggerModule from './logger';
 
 const logger = loggerModule.logger;
@@ -372,16 +374,23 @@ async function verifyGcpClaims(teeAttestation: TeeAttestation, expectedNonce: st
 
 /**
  * Validates the hardware TEE attestation included in the proof.
+ * Derives the application ID from `appSecret` and verifies the attestation
+ * was generated for your application.
  * Returns a result object with `isVerified` and an optional `error` message.
+ *
+ * @param proof - The proof containing TEE attestation data
+ * @param appSecret - Your application secret (Ethereum private key). Used to
+ *   derive the application ID and recompute the attestation nonce.
  */
 export async function verifyTeeAttestation(
     proof: Proof,
-    expectedApplicationId?: string,
-    expectedAppSecret?: string
+    appSecret: string
 ): Promise<TeeVerificationResult> {
     assertNonBrowserEnvironment();
 
     try {
+        const appId = new ethers.Wallet(appSecret).address;
+
         let teeAttestation = proof.teeAttestation;
         if (!teeAttestation) {
             throw new Error('Missing teeAttestation in proof');
@@ -394,8 +403,8 @@ export async function verifyTeeAttestation(
         assertProofShape(teeAttestation);
 
         const { parsedContext, nonceDataObj, expectedNonce } = parseProofContext(proof);
-        verifyApplicationAndSessionBinding(proof, parsedContext, nonceDataObj, expectedApplicationId);
-        verifyNonceMaterial(expectedNonce, nonceDataObj, expectedAppSecret);
+        verifyApplicationAndSessionBinding(proof, parsedContext, nonceDataObj, appId);
+        verifyNonceMaterial(expectedNonce, nonceDataObj, appSecret);
 
         const cleanExpectedNonce = normalizeHex(expectedNonce);
         const cleanTeeNonce = normalizeHex(teeAttestation.nonce);
@@ -412,5 +421,37 @@ export async function verifyTeeAttestation(
             isVerified: false,
             error: error instanceof Error ? error.message : String(error),
         };
+    }
+}
+
+/**
+ * Verifies TEE attestation for all proofs.
+ * Throws `TeeVerificationError` if any proof is missing TEE data or fails verification.
+ *
+ * @param proofs - The proofs to verify
+ * @param config - TEE attestation configuration containing the app secret
+ * @throws {TeeVerificationError} When TEE data is missing or verification fails
+ */
+export async function runTeeVerification(proofs: Proof[], config: TeeAttestationConfig): Promise<void> {
+    const hasTeeData = proofs.every(proof => {
+        if (proof.teeAttestation) return true;
+        try {
+            const context = JSON.parse(proof.claimData.context);
+            return !!context?.attestationNonce;
+        } catch {
+            return false;
+        }
+    });
+
+    if (!hasTeeData) {
+        throw new TeeVerificationError('TEE verification requested but one or more proofs are missing TEE attestation data');
+    }
+
+    const teeResults = await Promise.all(
+        proofs.map(proof => verifyTeeAttestation(proof, config.appSecret))
+    );
+
+    if (!teeResults.every(r => r.isVerified)) {
+        throw new TeeVerificationError('TEE attestation verification failed for one or more proofs');
     }
 }


### PR DESCRIPTION
### Description
- Replace boolean flag with config object. teeAttestation: { appSecret }  presence means intent. appId is derived internally via ethers.Wallet(appSecret).address.
- Consolidate TEE exports. Removed verifyTeeAttestationDetailed; verifyTeeAttestation nowreturns TeeVerificationResult ({ isVerified, error? }) instead of boolean.                 
- isTeeVerified is always boolean. No more undefined  predictable shape for consumers.
- Export types. TeeVerificationResult and TeeAttestationConfig are now exported.           

### Testing (ignore for documentation update)
 - Added coverage for: JWKS caching, malformed proof context, missing attestationNonce/attestationNonceData, teeAttestation as JSON string, missing teeAttestation
 - isTeeVerified asserted across all verifyProof tests                                      

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### Checklist:
- [x] I have read and agree to the [Code of Conduct](https://github.com/reclaimprotocol/.github/blob/main/Code-of-Conduct.md).
- [x] I have signed the [Contributor License Agreement (CLA)](https://github.com/reclaimprotocol/.github/blob/main/CLA.md).
- [x] I have considered the [Security Policy](https://github.com/reclaimprotocol/.github/blob/main/SECURITY.md).
- [x] I have self-reviewed and tested my code.
- [x] I have updated documentation as needed.
- [x] I agree to the [project's custom license](https://github.com/reclaimprotocol/.github/blob/main/LICENSE).

### Additional Notes:
n/a
