### PR TITLE
Feat/gcp tee verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Breaking:** `verifyTeeAttestation` now takes `(proof, appSecret)` instead of `(proof)`. It performs full GCP attestation verification and returns `{ isVerified, error? }` instead of a boolean. The application ID is derived from `appSecret` automatically.
 - **Breaking:** `verifyProof` config option renamed from `verifyTEE: boolean` to `teeAttestation: { appSecret }`. The app secret is now required so the SDK can verify application binding and recompute the attestation nonce.
+- **Breaking:** Renamed `isTeeVerified` to `isTeeAttestationVerified` on `VerifyProofResult`. Now returns `true` when TEE verification passes and `undefined` when not requested (previously `false`).
 
 ### Added
 
 - GCP TEE attestation verification: OIDC token signature validation, platform claims, nonce/digest binding, application and session binding.
 - New `runTeeVerification(proofs, config)` export for batch TEE verification that throws `TeeVerificationError` on failure.
-- `isTeeVerified` field on `VerifyProofResult` (always a boolean).
 - `TeeVerificationError` exported for catching TEE-specific failures.
 
 ## [5.1.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.2.0]
+
+### Changed
+
+- **Breaking:** `verifyTeeAttestation` now takes `(proof, appSecret)` instead of `(proof)`. It performs full GCP attestation verification and returns `{ isVerified, error? }` instead of a boolean. The application ID is derived from `appSecret` automatically.
+- **Breaking:** `verifyProof` config option renamed from `verifyTEE: boolean` to `teeAttestation: { appSecret }`. The app secret is now required so the SDK can verify application binding and recompute the attestation nonce.
+
+### Added
+- GCP TEE attestation verification: OIDC token signature validation, platform claims, nonce/digest binding, application and session binding.
+- `isTeeVerified` field on `VerifyProofResult` (always a boolean).
+- `TeeVerificationError` exported for catching TEE-specific failures.
+
 ## [5.1.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** `verifyProof` config option renamed from `verifyTEE: boolean` to `teeAttestation: { appSecret }`. The app secret is now required so the SDK can verify application binding and recompute the attestation nonce.
 
 ### Added
+
 - GCP TEE attestation verification: OIDC token signature validation, platform claims, nonce/digest binding, application and session binding.
+- New `runTeeVerification(proofs, config)` export for batch TEE verification that throws `TeeVerificationError` on failure.
 - `isTeeVerified` field on `VerifyProofResult` (always a boolean).
 - `TeeVerificationError` exported for catching TEE-specific failures.
 

--- a/README.md
+++ b/README.md
@@ -717,16 +717,16 @@ const proofRequest = await ReclaimProofRequest.init(APP_ID, APP_SECRET, PROVIDER
 
 ### Verifying TEE Attestation
 
-Set `verifyTEE: true` in the config to require and verify TEE attestation. If TEE data is missing or invalid, verification will fail with a `TeeVerificationError`.
+Provide a `teeAttestation` config to require and verify TEE attestation. If TEE data is missing or invalid, verification will fail with a `TeeVerificationError`.
 
 ```javascript
 import { verifyProof, TeeVerificationError } from "@reclaimprotocol/js-sdk";
 
-// Set verifyTEE in config to require TEE verification
 const { isVerified, isTeeVerified, data, error } = await verifyProof(proof, {
   hashes: ['0xAbC...'],
-  verifyTEE: true,
-  teeVerificationSecret: APP_SECRET,
+  teeAttestation: {
+    appSecret: APP_SECRET,
+  },
 });
 
 if (isVerified) {
@@ -740,26 +740,28 @@ if (isVerified) {
 }
 ```
 
-When `verifyTEE` is `true`, the result includes `isTeeVerified`. The overall `isVerified` will be `false` if TEE data is missing or TEE verification fails.
+The result always includes `isTeeVerified`. It is `true` only when `teeAttestation` was provided and verification passed; `false` otherwise. The overall `isVerified` will be `false` if TEE data is missing or TEE verification fails.
 
 The TEE verification validates:
 - **Nonce binding**: Ensures the attestation nonce matches the proof context
-- **Application ID**: Confirms the attestation was generated for your application (optional)
+- **Application ID**: Confirms the attestation was generated for your application
 - **Session and timestamp binding**: Verifies the nonce metadata matches the proof session and is within the allowed skew
-- **OIDC token signature**: Validates the Google Confidential Computing attestation JWT against Google's JWKS
+- **OIDC token signature**: Validates the Google Confidential Computing attestation JWT against Google's JWKS (cached for 5 minutes)
 - **Platform claims**: Confirms the expected GCP confidential-computing claims such as issuer, secure boot, hardware model, and GCE instance metadata
 - **Digest binding**: Confirms the workload and verifier image digests are present in the attestation token nonce list
 
-For hash-based attestation nonces, pass your **Application Secret** as `teeVerificationSecret` so the SDK can recompute the expected nonce locally.
+For hash-based attestation nonces, pass your **Application Secret** as `appSecret` so the SDK can recompute the expected nonce locally.
 
-You can also verify TEE attestation separately using the lower-level `verifyTeeAttestation` function:
+You can also verify TEE attestation separately using the standalone `verifyTeeAttestation` function:
 
 ```javascript
 import { verifyTeeAttestation } from "@reclaimprotocol/js-sdk";
 
-const isTeeValid = await verifyTeeAttestation(proof, APP_ID, APP_SECRET);
-if (isTeeValid) {
+const { isVerified, error } = await verifyTeeAttestation(proof, APP_ID, APP_SECRET);
+if (isVerified) {
   console.log("TEE attestation verified — proof was generated in a secure enclave");
+} else {
+  console.log("TEE verification failed:", error);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -703,7 +703,7 @@ const { isVerified } = await verifyProof(proof, {
 
 ## TEE Attestation Verification
 
-The SDK supports verifying TEE (Trusted Execution Environment) attestations included in proofs. This provides hardware-level assurance that the proof was generated inside a secure enclave (AMD SEV-SNP).
+The SDK supports verifying TEE (Trusted Execution Environment) attestations included in proofs. The current attestation flow verifies the Google Confidential Computing OIDC token returned by Popcorn's GCP attestor and checks that it is bound to the proof nonce and image digests.
 
 ### Enabling TEE Attestation
 
@@ -723,7 +723,11 @@ Set `verifyTEE: true` in the config to require and verify TEE attestation. If TE
 import { verifyProof, TeeVerificationError } from "@reclaimprotocol/js-sdk";
 
 // Set verifyTEE in config to require TEE verification
-const { isVerified, isTeeVerified, data, error } = await verifyProof(proof, { hashes: ['0xAbC...'], verifyTEE: true });
+const { isVerified, isTeeVerified, data, error } = await verifyProof(proof, {
+  hashes: ['0xAbC...'],
+  verifyTEE: true,
+  teeVerificationSecret: APP_SECRET,
+});
 
 if (isVerified) {
   console.log("Proof is fully verified with hardware attestation");
@@ -741,21 +745,50 @@ When `verifyTEE` is `true`, the result includes `isTeeVerified`. The overall `is
 The TEE verification validates:
 - **Nonce binding**: Ensures the attestation nonce matches the proof context
 - **Application ID**: Confirms the attestation was generated for your application (optional)
-- **Timestamp**: Verifies the attestation timestamp is within an acceptable range of the proof timestamp
-- **SNP report**: Validates the AMD SEV-SNP hardware attestation report
-- **VLEK certificate**: Verifies the certificate chain against AMD's root of trust
-- **Report data**: Confirms the workload and verifier digests match the attestation
+- **Session and timestamp binding**: Verifies the nonce metadata matches the proof session and is within the allowed skew
+- **OIDC token signature**: Validates the Google Confidential Computing attestation JWT against Google's JWKS
+- **Platform claims**: Confirms the expected GCP confidential-computing claims such as issuer, secure boot, hardware model, and GCE instance metadata
+- **Digest binding**: Confirms the workload and verifier image digests are present in the attestation token nonce list
+
+For hash-based attestation nonces, pass your **Application Secret** as `teeVerificationSecret` so the SDK can recompute the expected nonce locally.
 
 You can also verify TEE attestation separately using the lower-level `verifyTeeAttestation` function:
 
 ```javascript
 import { verifyTeeAttestation } from "@reclaimprotocol/js-sdk";
 
-const isTeeValid = await verifyTeeAttestation(proof, APP_ID);
+const isTeeValid = await verifyTeeAttestation(proof, APP_ID, APP_SECRET);
 if (isTeeValid) {
   console.log("TEE attestation verified — proof was generated in a secure enclave");
 }
 ```
+
+### Browser vs Server Verification
+
+TEE verification validates the Google Confidential Computing attestation JWT by fetching Google's OIDC metadata and JWKS. In browser-only environments this may fail due to cross-origin restrictions when fetching Google's discovery endpoints.
+
+For web apps, prefer verifying TEE attestations on the server:
+
+```javascript
+// POST your proof(s) to your server and verify there
+const response = await fetch('/api/verify-tee', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    proofs,
+    expectedApplicationId: APP_ID,
+    applicationSecret: APP_SECRET,
+  }),
+});
+
+const { results } = await response.json();
+console.log(results);
+```
+
+The example app included in this repository now uses a server route for TEE verification:
+- `example/src/app/api/verify-tee/route.ts`
+
+That route returns per-proof TEE verification results and failure reasons so the UI can show why verification failed.
 
 ## Error Handling
 

--- a/README.md
+++ b/README.md
@@ -703,7 +703,7 @@ const { isVerified } = await verifyProof(proof, {
 
 ## TEE Attestation Verification
 
-The SDK supports verifying TEE (Trusted Execution Environment) attestations included in proofs. The current attestation flow verifies the Google Confidential Computing OIDC token returned by Popcorn's GCP attestor and checks that it is bound to the proof nonce and image digests.
+The SDK supports verifying TEE (Trusted Execution Environment) attestations included in proofs. The attestation flow verifies the Google Confidential Computing OIDC token returned by Popcorn's GCP attestor and checks that it is bound to the proof nonce, application identity, and image digests.
 
 ### Enabling TEE Attestation
 
@@ -715,9 +715,9 @@ const proofRequest = await ReclaimProofRequest.init(APP_ID, APP_SECRET, PROVIDER
 });
 ```
 
-### Verifying TEE Attestation
+### Verifying TEE Attestation via `verifyProof`
 
-Provide a `teeAttestation` config to require and verify TEE attestation. If TEE data is missing or invalid, verification will fail with a `TeeVerificationError`.
+Provide a `teeAttestation` config to require and verify TEE attestation. The application ID is derived automatically from `appSecret`. If TEE data is missing or invalid, verification will fail with a `TeeVerificationError`.
 
 ```javascript
 import { verifyProof, TeeVerificationError } from "@reclaimprotocol/js-sdk";
@@ -730,8 +730,8 @@ const { isVerified, isTeeVerified, data, error } = await verifyProof(proof, {
 });
 
 if (isVerified) {
-  console.log("Proof is fully verified with hardware attestation");
-  console.log("TEE verified:", isTeeVerified);
+  console.log("Proof verified with hardware attestation");
+  console.log("TEE verified:", isTeeVerified); // always true when teeAttestation is provided and passes
   console.log("Extracted parameters:", data[0].extractedParameters);
 } else if (error instanceof TeeVerificationError) {
   console.log("TEE verification failed:", error.message);
@@ -740,57 +740,53 @@ if (isVerified) {
 }
 ```
 
-The result always includes `isTeeVerified`. It is `true` only when `teeAttestation` was provided and verification passed; `false` otherwise. The overall `isVerified` will be `false` if TEE data is missing or TEE verification fails.
+The result always includes `isTeeVerified` as a boolean. It is `true` only when `teeAttestation` was provided and verification passed; `false` otherwise.
 
-The TEE verification validates:
+### What TEE verification checks
+
+- **Application binding**: Derives the application ID from `appSecret` and confirms the attestation was generated for your application
 - **Nonce binding**: Ensures the attestation nonce matches the proof context
-- **Application ID**: Confirms the attestation was generated for your application
 - **Session and timestamp binding**: Verifies the nonce metadata matches the proof session and is within the allowed skew
-- **OIDC token signature**: Validates the Google Confidential Computing attestation JWT against Google's JWKS (cached for 5 minutes)
-- **Platform claims**: Confirms the expected GCP confidential-computing claims such as issuer, secure boot, hardware model, and GCE instance metadata
+- **OIDC token signature**: Validates the Google Confidential Computing attestation JWT against Google's JWKS (responses are cached for 5 minutes)
+- **Platform claims**: Confirms the expected GCP confidential-computing claims (issuer, secure boot, hardware model, GCE instance metadata)
 - **Digest binding**: Confirms the workload and verifier image digests are present in the attestation token nonce list
 
-For hash-based attestation nonces, pass your **Application Secret** as `appSecret` so the SDK can recompute the expected nonce locally.
+### Standalone `verifyTeeAttestation`
 
-You can also verify TEE attestation separately using the standalone `verifyTeeAttestation` function:
+You can verify TEE attestation for a single proof without running full proof verification:
 
 ```javascript
 import { verifyTeeAttestation } from "@reclaimprotocol/js-sdk";
 
-const { isVerified, error } = await verifyTeeAttestation(proof, APP_ID, APP_SECRET);
+const { isVerified, error } = await verifyTeeAttestation(proof, APP_SECRET);
 if (isVerified) {
-  console.log("TEE attestation verified — proof was generated in a secure enclave");
+  console.log("TEE attestation verified");
 } else {
   console.log("TEE verification failed:", error);
 }
 ```
 
+`appSecret` is your Reclaim application secret. The application ID is derived from it automatically.
+
 ### Browser vs Server Verification
 
-TEE verification validates the Google Confidential Computing attestation JWT by fetching Google's OIDC metadata and JWKS. In browser-only environments this may fail due to cross-origin restrictions when fetching Google's discovery endpoints.
+TEE verification fetches Google's OIDC metadata and JWKS endpoints. In browser-only environments this may fail due to cross-origin restrictions.
 
-For web apps, prefer verifying TEE attestations on the server:
+For web apps, verify TEE attestations on the server:
 
 ```javascript
-// POST your proof(s) to your server and verify there
 const response = await fetch('/api/verify-tee', {
   method: 'POST',
   headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify({
-    proofs,
-    expectedApplicationId: APP_ID,
-    applicationSecret: APP_SECRET,
-  }),
+  body: JSON.stringify({ proofs }),
 });
 
 const { results } = await response.json();
 console.log(results);
 ```
 
-The example app included in this repository now uses a server route for TEE verification:
+The server route should read the app secret from environment variables only (never accept it from the client request body). See the example app for a reference implementation:
 - `example/src/app/api/verify-tee/route.ts`
-
-That route returns per-proof TEE verification results and failure reasons so the UI can show why verification failed.
 
 ## Error Handling
 

--- a/README.md
+++ b/README.md
@@ -722,7 +722,7 @@ Provide a `teeAttestation` config to require and verify TEE attestation. The app
 ```javascript
 import { verifyProof, TeeVerificationError } from "@reclaimprotocol/js-sdk";
 
-const { isVerified, isTeeVerified, data, error } = await verifyProof(proof, {
+const { isVerified, isTeeAttestationVerified, data, error } = await verifyProof(proof, {
   hashes: ['0xAbC...'],
   teeAttestation: {
     appSecret: APP_SECRET,
@@ -731,7 +731,7 @@ const { isVerified, isTeeVerified, data, error } = await verifyProof(proof, {
 
 if (isVerified) {
   console.log("Proof verified with hardware attestation");
-  console.log("TEE verified:", isTeeVerified); // always true when teeAttestation is provided and passes
+  console.log("TEE verified:", isTeeAttestationVerified); // always true when teeAttestation is provided and passes
   console.log("Extracted parameters:", data[0].extractedParameters);
 } else if (error instanceof TeeVerificationError) {
   console.log("TEE verification failed:", error.message);
@@ -740,7 +740,7 @@ if (isVerified) {
 }
 ```
 
-The result always includes `isTeeVerified` as a boolean. It is `true` only when `teeAttestation` was provided and verification passed; `false` otherwise.
+The result includes `isTeeAttestationVerified`. It is `true` when `teeAttestation` was provided and verification passed, and `undefined` when `teeAttestation` was not requested.
 
 ### What TEE verification checks
 

--- a/example/next.config.mjs
+++ b/example/next.config.mjs
@@ -1,4 +1,9 @@
+import path from 'path'
+
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  outputFileTracingRoot: path.join(process.cwd(), '..'),
+  transpilePackages: ['@reclaimprotocol/js-sdk'],
+};
 
 export default nextConfig;

--- a/example/src/app/api/verify-tee/route.ts
+++ b/example/src/app/api/verify-tee/route.ts
@@ -18,16 +18,11 @@ export async function POST(request: Request) {
       )
     }
 
-    const applicationId = process.env.RECLAIM_APP_ID || process.env.NEXT_PUBLIC_RECLAIM_APP_ID
     const appSecret = process.env.RECLAIM_APP_SECRET || process.env.NEXT_PUBLIC_RECLAIM_APP_SECRET
 
     const results = await Promise.all(
       proofs.map(async (proof, index) => {
-        const result = await verifyTeeAttestation(
-          proof,
-          applicationId,
-          appSecret
-        )
+        const result = await verifyTeeAttestation(proof, appSecret!)
 
         return {
           index,

--- a/example/src/app/api/verify-tee/route.ts
+++ b/example/src/app/api/verify-tee/route.ts
@@ -1,12 +1,9 @@
 import { NextResponse } from 'next/server'
-import { verifyTeeAttestationDetailed } from '@reclaimprotocol/js-sdk'
+import { verifyTeeAttestation } from '@reclaimprotocol/js-sdk'
 import type { Proof } from '@reclaimprotocol/js-sdk'
 
 type VerifyTeeRequestBody = {
   proofs?: Proof[]
-  expectedApplicationId?: string
-  applicationSecret?: string
-  teeVerificationSecret?: string
 }
 
 export async function POST(request: Request) {
@@ -21,27 +18,15 @@ export async function POST(request: Request) {
       )
     }
 
-    const expectedApplicationId =
-      body.expectedApplicationId ||
-      process.env.RECLAIM_APP_ID ||
-      process.env.NEXT_PUBLIC_RECLAIM_APP_ID
-
-    const applicationSecret =
-      body.applicationSecret ||
-      body.teeVerificationSecret ||
-      process.env.RECLAIM_APP_SECRET ||
-      process.env.NEXT_PUBLIC_RECLAIM_APP_SECRET
-
-    const teeVerificationSecret =
-      body.teeVerificationSecret ||
-      applicationSecret
+    const applicationId = process.env.RECLAIM_APP_ID || process.env.NEXT_PUBLIC_RECLAIM_APP_ID
+    const appSecret = process.env.RECLAIM_APP_SECRET || process.env.NEXT_PUBLIC_RECLAIM_APP_SECRET
 
     const results = await Promise.all(
       proofs.map(async (proof, index) => {
-        const result = await verifyTeeAttestationDetailed(
+        const result = await verifyTeeAttestation(
           proof,
-          expectedApplicationId,
-          teeVerificationSecret
+          applicationId,
+          appSecret
         )
 
         return {

--- a/example/src/app/api/verify-tee/route.ts
+++ b/example/src/app/api/verify-tee/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from 'next/server'
+import { verifyTeeAttestationDetailed } from '@reclaimprotocol/js-sdk'
+import type { Proof } from '@reclaimprotocol/js-sdk'
+
+type VerifyTeeRequestBody = {
+  proofs?: Proof[]
+  expectedApplicationId?: string
+  applicationSecret?: string
+  teeVerificationSecret?: string
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json() as VerifyTeeRequestBody
+    const proofs = Array.isArray(body.proofs) ? body.proofs : []
+
+    if (proofs.length === 0) {
+      return NextResponse.json(
+        { error: 'Request body must include a non-empty `proofs` array' },
+        { status: 400 }
+      )
+    }
+
+    const expectedApplicationId =
+      body.expectedApplicationId ||
+      process.env.RECLAIM_APP_ID ||
+      process.env.NEXT_PUBLIC_RECLAIM_APP_ID
+
+    const applicationSecret =
+      body.applicationSecret ||
+      body.teeVerificationSecret ||
+      process.env.RECLAIM_APP_SECRET ||
+      process.env.NEXT_PUBLIC_RECLAIM_APP_SECRET
+
+    const teeVerificationSecret =
+      body.teeVerificationSecret ||
+      applicationSecret
+
+    const results = await Promise.all(
+      proofs.map(async (proof, index) => {
+        const result = await verifyTeeAttestationDetailed(
+          proof,
+          expectedApplicationId,
+          teeVerificationSecret
+        )
+
+        return {
+          index,
+          isTeeVerified: result.isVerified,
+          error: result.error,
+        }
+      })
+    )
+
+    return NextResponse.json({ results })
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : 'Failed to verify TEE attestations',
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/example/src/app/api/verify-tee/route.ts
+++ b/example/src/app/api/verify-tee/route.ts
@@ -26,7 +26,7 @@ export async function POST(request: Request) {
 
         return {
           index,
-          isTeeVerified: result.isVerified,
+          isTeeAttestationVerified: result.isVerified,
           error: result.error,
         }
       })

--- a/example/src/app/page.tsx
+++ b/example/src/app/page.tsx
@@ -69,12 +69,15 @@ export default function Home() {
         process.env.NEXT_PUBLIC_RECLAIM_PROVIDER_ID!,
         {
           log: true,
-          acceptTeeAttestation: true,
+          // acceptTeeAttestation: true,
           useAppClip: false,
-          customSharePageUrl: 'http://localhost:5173',
+          // portalUrl: 'https://portal.reclaimprotocol.org', // default
+          // launchOptions: { verificationMode: 'app' }, // for native app flow
+          // useAppClip: true, // for App Clip on iOS with verificationMode: 'app'
+          // portalUrl: 'https://portal.reclaimprotocol.org', 
         }
       )
-      proofRequest.setAppCallbackUrl('https://webhook.site/f2eb69c1-2dfc-4304-81f5-418393154487', true)
+      proofRequest.setAppCallbackUrl('<YOUR_APP_CALLBACK_URL>', true)
       setReclaimProofRequest(proofRequest)
       return proofRequest
     } catch (error) {

--- a/example/src/app/page.tsx
+++ b/example/src/app/page.tsx
@@ -1,18 +1,65 @@
 'use client'
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { ReclaimProofRequest, verifyProof } from '@reclaimprotocol/js-sdk'
 import type { Proof, VerifyProofResult } from '@reclaimprotocol/js-sdk'
+
+type TeeCheckResult = {
+  index: number
+  isTeeVerified: boolean
+  error?: string
+}
 
 export default function Home() {
   const [isLoading, setIsLoading] = useState(false)
   const [proofData, setProofData] = useState<Proof[] | null>(null)
   const [verifyResult, setVerifyResult] = useState<VerifyProofResult | null>(null)
+  const [teeResults, setTeeResults] = useState<TeeCheckResult[] | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [reclaimProofRequest, setReclaimProofRequest] = useState<ReclaimProofRequest | null>(null)
+  const [requestUrl, setRequestUrl] = useState<string | null>(null)
+  const [proofJsonInput, setProofJsonInput] = useState('')
+  const [applicationSecretInput, setApplicationSecretInput] = useState(process.env.NEXT_PUBLIC_RECLAIM_APP_SECRET ?? '')
 
-  useEffect(() => {
-    initializeReclaimProofRequest()
-  }, [])
+  async function verifyTeeOnServer(proofs: Proof[]): Promise<TeeCheckResult[]> {
+    const response = await fetch('/api/verify-tee', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        proofs,
+        expectedApplicationId: process.env.NEXT_PUBLIC_RECLAIM_APP_ID,
+        applicationSecret: applicationSecretInput.trim() || undefined,
+      }),
+    })
+
+    const payload = await response.json()
+    if (!response.ok) {
+      throw new Error(payload?.error || 'Failed to verify TEE attestations on the server')
+    }
+
+    return payload.results as TeeCheckResult[]
+  }
+
+  async function runVerification(proofs: Proof[], options?: { strictProofConfig?: Parameters<typeof verifyProof>[1] }) {
+    const proofVerification = await verifyProof(
+      proofs,
+      options?.strictProofConfig ?? { dangerouslyDisableContentValidation: true }
+    )
+
+    const teeVerification = await verifyTeeOnServer(proofs)
+
+    setVerifyResult(proofVerification)
+    setTeeResults(teeVerification)
+  }
+
+  function parseProofInput(input: string): Proof[] {
+    const parsed = JSON.parse(input)
+    if (Array.isArray(parsed)) {
+      return parsed as Proof[]
+    }
+    return [parsed as Proof]
+  }
 
   async function initializeReclaimProofRequest() {
     try {
@@ -22,56 +69,49 @@ export default function Home() {
         process.env.NEXT_PUBLIC_RECLAIM_PROVIDER_ID!,
         {
           log: true,
-          // portalUrl: 'https://portal.reclaimprotocol.org', // default
-          // launchOptions: { verificationMode: 'app' }, // for native app flow
-          // useAppClip: true, // for App Clip on iOS with verificationMode: 'app'
+          acceptTeeAttestation: true,
+          useAppClip: false,
+          customSharePageUrl: 'http://localhost:5173',
         }
       )
+      proofRequest.setAppCallbackUrl('https://webhook.site/f2eb69c1-2dfc-4304-81f5-418393154487', true)
       setReclaimProofRequest(proofRequest)
+      return proofRequest
     } catch (error) {
       console.error('Error initializing ReclaimProofRequest:', error)
       setError('Failed to initialize Reclaim. Please try again.')
+      return null
     }
   }
 
   async function startClaimProcess() {
-    if (!reclaimProofRequest) {
-      setError('Reclaim not initialized. Please refresh the page.')
-      return
-    }
-
     setIsLoading(true)
     setError(null)
 
+    let proofRequest = reclaimProofRequest;
+    if (!proofRequest) {
+      proofRequest = await initializeReclaimProofRequest();
+      if (!proofRequest) {
+        setIsLoading(false);
+        return;
+      }
+    }
+
     try {
-      // Portal flow (default) — opens portal in new tab
-      await reclaimProofRequest.triggerReclaimFlow()
+      const url = await proofRequest.getRequestUrl()
+      setRequestUrl(url)
 
-      // For native app flow, use:
-      //await reclaimProofRequest.triggerReclaimFlow({ verificationMode: 'app'})
-
-      await reclaimProofRequest.startSession({
+      await proofRequest.startSession({
         onSuccess: async (proof: Proof | Proof[] | undefined) => {
           setIsLoading(false)
 
           if (proof && typeof proof !== 'string') {
             const proofs = Array.isArray(proof) ? proof : [proof]
             setProofData(proofs)
+            setProofJsonInput(JSON.stringify(proofs, null, 2))
 
-            // Verify proofs and get extracted data
-            const providerVersion = reclaimProofRequest.getProviderVersion()
-            const { isVerified, data } = await verifyProof(proofs, providerVersion)
-            setVerifyResult({ isVerified, data })
-
-            if (isVerified) {
-              console.log('Proofs verified successfully')
-              data.forEach((d, i) => {
-                console.log(`Proof ${i + 1} context:`, d.context)
-                console.log(`Proof ${i + 1} params:`, d.extractedParameters)
-              })
-            } else {
-              console.warn('Proof verification failed')
-            }
+            const providerVersion = proofRequest.getProviderVersion()
+            await runVerification(proofs, { strictProofConfig: providerVersion })
           }
         },
         onError: (error: Error) => {
@@ -87,6 +127,26 @@ export default function Home() {
     }
   }
 
+  async function verifyPastedProof() {
+    try {
+      setError(null)
+      setIsLoading(true)
+
+      const proofs = parseProofInput(proofJsonInput)
+      setProofData(proofs)
+      setRequestUrl(null)
+      await runVerification(proofs)
+    } catch (error) {
+      console.error('Error verifying pasted proof:', error)
+      setVerifyResult(null)
+      setTeeResults(null)
+      setProofData(null)
+      setError(error instanceof Error ? error.message : 'Failed to verify pasted proof')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
   const getProviderUrl = (proof: Proof) => {
     try {
       const parameters = JSON.parse(proof.claimData.parameters)
@@ -96,12 +156,74 @@ export default function Home() {
     }
   }
 
+  const teeVerifiedCount = teeResults?.filter(result => result.isTeeVerified).length ?? 0
+
   return (
     <main className='flex min-h-screen flex-col items-center p-8 bg-gray-50'>
       <div className='max-w-4xl w-full mx-auto'>
         <h1 className='text-3xl font-bold mb-8 text-center'>Reclaim SDK</h1>
 
-        {!proofData && !isLoading && (
+        <div className="mb-8 rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+          <h2 className="text-xl font-semibold text-gray-900">Verify Pasted Proof</h2>
+          <p className="mt-2 text-sm text-gray-600">
+            Paste a proof JSON object or array below to verify the witness proof and the TEE attestation from the UI.
+          </p>
+
+          <div className="mt-4 space-y-4">
+            <div>
+              <label className="mb-2 block text-sm font-medium text-gray-700">
+                Proof JSON
+              </label>
+              <textarea
+                value={proofJsonInput}
+                onChange={(event) => setProofJsonInput(event.target.value)}
+                placeholder='Paste proof JSON here'
+                className="min-h-[240px] w-full rounded-lg border border-gray-300 p-3 font-mono text-sm text-gray-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+              />
+            </div>
+
+            <div>
+              <label className="mb-2 block text-sm font-medium text-gray-700">
+                Application Secret
+              </label>
+              <input
+                type="text"
+                value={applicationSecretInput}
+                onChange={(event) => setApplicationSecretInput(event.target.value)}
+                placeholder="Required for hash-based attestation nonces"
+                className="w-full rounded-lg border border-gray-300 p-3 text-sm text-gray-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+              />
+              <p className="mt-2 text-xs text-gray-500">
+                This should be your Reclaim application secret so the TEE nonce can be recomputed locally.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <button
+                onClick={verifyPastedProof}
+                disabled={isLoading || !proofJsonInput.trim()}
+                className="rounded-lg bg-emerald-600 px-5 py-3 font-medium text-white shadow-md transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:bg-emerald-300"
+              >
+                Verify Pasted Proof + TEE
+              </button>
+              <button
+                onClick={() => {
+                  setProofJsonInput('')
+                  setProofData(null)
+                  setVerifyResult(null)
+                  setTeeResults(null)
+                  setError(null)
+                  setRequestUrl(null)
+                }}
+                className="rounded-lg border border-gray-300 px-5 py-3 font-medium text-gray-700 transition hover:bg-gray-50"
+              >
+                Clear
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {!proofData && !isLoading && !requestUrl && (
           <div className="text-center">
             <p className="mb-6 text-gray-700">
               Click the button below to start the claim process.
@@ -109,10 +231,23 @@ export default function Home() {
             <button
               onClick={startClaimProcess}
               className='bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 px-6 rounded-lg transition-colors shadow-md'
-              disabled={!reclaimProofRequest}
             >
               Start Claim Process
             </button>
+          </div>
+        )}
+
+        {requestUrl && !proofData && (
+          <div className="text-center mt-6">
+            <p className="mb-4">Please complete the verification using this link:</p>
+            <a
+              href={requestUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 underline font-medium break-all"
+            >
+              {requestUrl}
+            </a>
           </div>
         )}
 
@@ -144,14 +279,42 @@ export default function Home() {
               </div>
             )}
 
+            {teeResults && (
+              <div className={`mb-6 rounded-md border p-4 text-sm font-medium ${teeVerifiedCount === teeResults.length
+                ? 'border-green-200 bg-green-50 text-green-700'
+                : 'border-amber-200 bg-amber-50 text-amber-700'
+                }`}>
+                {teeVerifiedCount === teeResults.length
+                  ? `TEE verification passed for all ${teeResults.length} proof(s)`
+                  : `TEE verification passed for ${teeVerifiedCount}/${teeResults.length} proof(s)`}
+              </div>
+            )}
+
             {proofData.map((proof, index) => (
               <div key={index} className="mb-8 bg-white p-8 rounded-lg border border-gray-200 shadow-sm hover:shadow-md transition-shadow">
                 <div className="flex justify-between items-start mb-4">
-                  <h3 className="text-xl font-medium">Proof #{index + 1}</h3>
+                  <div>
+                    <h3 className="text-xl font-medium">Proof #{index + 1}</h3>
+                    {teeResults && (
+                      <p className={`mt-2 inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${teeResults[index]?.isTeeVerified
+                        ? 'bg-green-100 text-green-800'
+                        : 'bg-amber-100 text-amber-800'
+                        }`}>
+                        {teeResults[index]?.isTeeVerified ? 'TEE Verified' : 'TEE Not Verified'}
+                      </p>
+                    )}
+                  </div>
                   {verifyResult?.isVerified && (
-                    <span className="bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded-full">Verified</span>
+                    <span className="bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded-full">Proof Verified</span>
                   )}
                 </div>
+
+                {teeResults && !teeResults[index]?.isTeeVerified && teeResults[index]?.error && (
+                  <div className="mb-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+                    <p className="font-medium">TEE verification reason</p>
+                    <p className="mt-1 break-all font-mono text-xs">{teeResults[index]?.error}</p>
+                  </div>
+                )}
 
                 <div className="grid grid-cols-1 gap-4 mb-4">
                   <div>
@@ -163,6 +326,34 @@ export default function Home() {
                     <p>{new Date(proof.claimData.timestampS * 1000).toLocaleString()}</p>
                   </div>
                 </div>
+
+                {proof.teeAttestation && (
+                  <div className="mt-5 pt-4 border-t border-gray-100">
+                    <p className="text-sm font-medium text-gray-500 mb-2">TEE Attestation Summary</p>
+                    <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                      <div className="rounded bg-gray-50 p-3">
+                        <p className="text-xs font-medium uppercase tracking-wide text-gray-500">TEE Provider</p>
+                        <p className="mt-1 font-medium">{proof.teeAttestation.tee_provider}</p>
+                      </div>
+                      <div className="rounded bg-gray-50 p-3">
+                        <p className="text-xs font-medium uppercase tracking-wide text-gray-500">TEE Technology</p>
+                        <p className="mt-1 font-medium">{proof.teeAttestation.tee_technology}</p>
+                      </div>
+                      <div className="rounded bg-gray-50 p-3 md:col-span-2">
+                        <p className="text-xs font-medium uppercase tracking-wide text-gray-500">TEE Nonce</p>
+                        <p className="mt-1 break-all font-mono text-sm">{proof.teeAttestation.nonce}</p>
+                      </div>
+                      <div className="rounded bg-gray-50 p-3 md:col-span-2">
+                        <p className="text-xs font-medium uppercase tracking-wide text-gray-500">Workload Image</p>
+                        <p className="mt-1 break-all font-mono text-sm">{proof.teeAttestation.workload.image_digest}</p>
+                      </div>
+                      <div className="rounded bg-gray-50 p-3 md:col-span-2">
+                        <p className="text-xs font-medium uppercase tracking-wide text-gray-500">Verifier Image</p>
+                        <p className="mt-1 break-all font-mono text-sm">{proof.teeAttestation.verifier.image_digest}</p>
+                      </div>
+                    </div>
+                  </div>
+                )}
 
                 {/* Extracted parameters from verifyProof result */}
                 {verifyResult?.isVerified && verifyResult.data[index] && (
@@ -220,7 +411,11 @@ export default function Home() {
             ))}
 
             <button
-              onClick={() => { setProofData(null); setVerifyResult(null) }}
+              onClick={() => {
+                setProofData(null)
+                setVerifyResult(null)
+                setTeeResults(null)
+              }}
               className="mt-4 px-6 py-3 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors font-medium shadow-sm w-full md:w-auto"
             >
               Start New Claim

--- a/example/src/app/page.tsx
+++ b/example/src/app/page.tsx
@@ -18,19 +18,12 @@ export default function Home() {
   const [reclaimProofRequest, setReclaimProofRequest] = useState<ReclaimProofRequest | null>(null)
   const [requestUrl, setRequestUrl] = useState<string | null>(null)
   const [proofJsonInput, setProofJsonInput] = useState('')
-  const [applicationSecretInput, setApplicationSecretInput] = useState(process.env.NEXT_PUBLIC_RECLAIM_APP_SECRET ?? '')
 
   async function verifyTeeOnServer(proofs: Proof[]): Promise<TeeCheckResult[]> {
     const response = await fetch('/api/verify-tee', {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        proofs,
-        expectedApplicationId: process.env.NEXT_PUBLIC_RECLAIM_APP_ID,
-        applicationSecret: applicationSecretInput.trim() || undefined,
-      }),
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ proofs }),
     })
 
     const payload = await response.json()
@@ -41,10 +34,10 @@ export default function Home() {
     return payload.results as TeeCheckResult[]
   }
 
-  async function runVerification(proofs: Proof[], options?: { strictProofConfig?: Parameters<typeof verifyProof>[1] }) {
+  async function runVerification(proofs: Proof[], proofConfig?: Parameters<typeof verifyProof>[1]) {
     const proofVerification = await verifyProof(
       proofs,
-      options?.strictProofConfig ?? { dangerouslyDisableContentValidation: true }
+      proofConfig ?? { dangerouslyDisableContentValidation: true }
     )
 
     const teeVerification = await verifyTeeOnServer(proofs)
@@ -69,14 +62,16 @@ export default function Home() {
         process.env.NEXT_PUBLIC_RECLAIM_PROVIDER_ID!,
         {
           log: true,
-          // acceptTeeAttestation: true,
+          acceptTeeAttestation: true,
+          canAutoSubmit: false
           // portalUrl: 'https://portal.reclaimprotocol.org', // default
           // launchOptions: { verificationMode: 'app' }, // for native app flow
           // useAppClip: true, // for App Clip on iOS with verificationMode: 'app'
           // portalUrl: 'https://portal.reclaimprotocol.org', 
         }
       )
-      proofRequest.setAppCallbackUrl('<YOUR_APP_CALLBACK_URL>', true)
+      //proofRequest.setAppCallbackUrl('https://webhooksite.net/cf05ecdb-2963-4555-83a4-61b24880d48a', true)
+      //proofRequest.setAppCallbackUrl('<YOUR_APP_CALLBACK_URL>', true)
       
 
       setReclaimProofRequest(proofRequest)
@@ -115,7 +110,7 @@ export default function Home() {
             setProofJsonInput(JSON.stringify(proofs, null, 2))
 
             const providerVersion = proofRequest.getProviderVersion()
-            await runVerification(proofs, { strictProofConfig: providerVersion })
+            await runVerification(proofs, providerVersion as Parameters<typeof verifyProof>[1])
           }
         },
         onError: (error: Error) => {
@@ -184,22 +179,6 @@ export default function Home() {
                 placeholder='Paste proof JSON here'
                 className="min-h-[240px] w-full rounded-lg border border-gray-300 p-3 font-mono text-sm text-gray-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
               />
-            </div>
-
-            <div>
-              <label className="mb-2 block text-sm font-medium text-gray-700">
-                Application Secret
-              </label>
-              <input
-                type="text"
-                value={applicationSecretInput}
-                onChange={(event) => setApplicationSecretInput(event.target.value)}
-                placeholder="Required for hash-based attestation nonces"
-                className="w-full rounded-lg border border-gray-300 p-3 text-sm text-gray-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-              />
-              <p className="mt-2 text-xs text-gray-500">
-                This should be your Reclaim application secret so the TEE nonce can be recomputed locally.
-              </p>
             </div>
 
             <div className="flex flex-col gap-3 sm:flex-row">

--- a/example/src/app/page.tsx
+++ b/example/src/app/page.tsx
@@ -5,7 +5,7 @@ import type { Proof, VerifyProofResult } from '@reclaimprotocol/js-sdk'
 
 type TeeCheckResult = {
   index: number
-  isTeeVerified: boolean
+  isTeeAttestationVerified: boolean
   error?: string
 }
 
@@ -155,7 +155,7 @@ export default function Home() {
     }
   }
 
-  const teeVerifiedCount = teeResults?.filter(result => result.isTeeVerified).length ?? 0
+  const teeVerifiedCount = teeResults?.filter(result => result.isTeeAttestationVerified).length ?? 0
 
   return (
     <main className='flex min-h-screen flex-col items-center p-8 bg-gray-50'>
@@ -279,11 +279,11 @@ export default function Home() {
                   <div>
                     <h3 className="text-xl font-medium">Proof #{index + 1}</h3>
                     {teeResults && (
-                      <p className={`mt-2 inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${teeResults[index]?.isTeeVerified
+                      <p className={`mt-2 inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${teeResults[index]?.isTeeAttestationVerified
                         ? 'bg-green-100 text-green-800'
                         : 'bg-amber-100 text-amber-800'
                         }`}>
-                        {teeResults[index]?.isTeeVerified ? 'TEE Verified' : 'TEE Not Verified'}
+                        {teeResults[index]?.isTeeAttestationVerified ? 'TEE Verified' : 'TEE Not Verified'}
                       </p>
                     )}
                   </div>
@@ -292,7 +292,7 @@ export default function Home() {
                   )}
                 </div>
 
-                {teeResults && !teeResults[index]?.isTeeVerified && teeResults[index]?.error && (
+                {teeResults && !teeResults[index]?.isTeeAttestationVerified && teeResults[index]?.error && (
                   <div className="mb-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
                     <p className="font-medium">TEE verification reason</p>
                     <p className="mt-1 break-all font-mono text-xs">{teeResults[index]?.error}</p>

--- a/example/src/app/page.tsx
+++ b/example/src/app/page.tsx
@@ -70,7 +70,6 @@ export default function Home() {
         {
           log: true,
           // acceptTeeAttestation: true,
-          useAppClip: false,
           // portalUrl: 'https://portal.reclaimprotocol.org', // default
           // launchOptions: { verificationMode: 'app' }, // for native app flow
           // useAppClip: true, // for App Clip on iOS with verificationMode: 'app'
@@ -78,6 +77,8 @@ export default function Home() {
         }
       )
       proofRequest.setAppCallbackUrl('<YOUR_APP_CALLBACK_URL>', true)
+      
+
       setReclaimProofRequest(proofRequest)
       return proofRequest
     } catch (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reclaimprotocol/js-sdk",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@reclaimprotocol/js-sdk",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "license": "See License in <https://github.com/reclaimprotocol/.github/blob/main/LICENSE>",
       "dependencies": {
         "canonicalize": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reclaimprotocol/js-sdk",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Designed to request proofs from the Reclaim protocol and manage the flow of claims and witness interactions.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -70,7 +70,7 @@ const sdkVersion = require('../package.json').version;
  *
  * @param proofOrProofs - A single proof object or an array of proof objects to be verified.
  * @param config - Verification configuration that specifies required hashes, allowed extra hashes, or disables content validation. Optionally includes `teeAttestation` to require TEE attestation verification.
- * @returns Verification result with `isVerified`, `isTeeVerified` (always boolean), extracted `data` from each proof, and optional `error` on failure. The application ID is derived from `appSecret` automatically.
+ * @returns Verification result with `isVerified`, `isTeeAttestationVerified` (always boolean), extracted `data` from each proof, and optional `error` on failure. The application ID is derived from `appSecret` automatically.
  *
  * @example
  * ```typescript
@@ -78,7 +78,7 @@ const sdkVersion = require('../package.json').version;
  * const { isVerified, data } = await verifyProof(proof, request.getProviderVersion());
  *
  * // With TEE attestation verification (fails if TEE data is missing or invalid)
- * const { isVerified, isTeeVerified, data } = await verifyProof(proof, { ...request.getProviderVersion(), teeAttestation: { appSecret: APP_SECRET } });
+ * const { isVerified, isTeeAttestationVerified, data } = await verifyProof(proof, { ...request.getProviderVersion(), teeAttestation: { appSecret: APP_SECRET } });
  * 
  * // Or, by manually providing the details:
  * 
@@ -137,7 +137,7 @@ export async function verifyProof(
 
         await assertValidateProof(proofs, config);
 
-        let isTeeVerified = false;
+        let isTeeAttestationVerified: boolean | undefined;
 
         if (config.teeAttestation && 'dangerouslyDisableContentValidation' in config && config.dangerouslyDisableContentValidation) {
             logger.warn('teeAttestation is enabled but content validation is disabled — TEE attestation alone does not guarantee proof contents are valid');
@@ -145,10 +145,10 @@ export async function verifyProof(
 
         if (config.teeAttestation) {
             await runTeeVerification(proofs, config.teeAttestation);
-            isTeeVerified = true;
+            isTeeAttestationVerified = true;
         }
 
-        return createVerifyProofResultSuccess(proofs, isTeeVerified);
+        return createVerifyProofResultSuccess(proofs, isTeeAttestationVerified);
     } catch (error) {
         logger.error('Error in validating proof:', error);
         const _error = error instanceof Error ? error : new Error(String(error));

--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -40,7 +40,6 @@ import {
     ErrorDuringVerificationError,
     CallbackUrlRequiredError,
     ProofNotValidatedError,
-    TeeVerificationError
 } from './utils/errors';
 import { validateContext, validateFunctionParams, validateParameters, validateSignature, validateURL, validateModalOptions, validateFunctionParamsWithFn, validateRedirectionMethod, validateRedirectionBody } from './utils/validationUtils'
 import { fetchStatusUrl, initSession, updateSession } from './utils/sessionUtils'
@@ -51,7 +50,7 @@ import { getDeviceType, getMobileDeviceType } from './utils/device'
 import { generateAttestationNonce } from './utils/attestationNonce'
 import { canonicalStringify } from './utils/strings'
 import { assertValidateProof, VerificationConfig } from './utils/proofValidationUtils'
-import { verifyTeeAttestation } from './utils/verifyTee'
+import { runTeeVerification } from './utils/verifyTee'
 import { fetchProviderHashRequirementsBy, ProviderHashRequirementsConfig } from './utils/providerUtils'
 
 const logger = loggerModule.logger
@@ -71,7 +70,7 @@ const sdkVersion = require('../package.json').version;
  *
  * @param proofOrProofs - A single proof object or an array of proof objects to be verified.
  * @param config - Verification configuration that specifies required hashes, allowed extra hashes, or disables content validation. Optionally includes `teeAttestation` to require TEE attestation verification.
- * @returns Verification result with `isVerified`, extracted `data` from each proof, optional `error` on failure, and `isTeeVerified` when `teeAttestation` is provided.
+ * @returns Verification result with `isVerified`, `isTeeVerified` (always boolean), extracted `data` from each proof, and optional `error` on failure. The application ID is derived from `appSecret` automatically.
  *
  * @example
  * ```typescript
@@ -140,44 +139,13 @@ export async function verifyProof(
 
         let isTeeVerified = false;
 
-        if (config.teeAttestation && 'dangerouslyDisableContentValidation' in config) {
+        if (config.teeAttestation && 'dangerouslyDisableContentValidation' in config && config.dangerouslyDisableContentValidation) {
             logger.warn('teeAttestation is enabled but content validation is disabled — TEE attestation alone does not guarantee proof contents are valid');
         }
 
         if (config.teeAttestation) {
-            const hasTeeData = proofs.every(proof => {
-                if (proof.teeAttestation) return true;
-                try {
-                    const context = JSON.parse(proof.claimData.context);
-                    return !!context?.attestationNonce;
-                } catch {
-                    return false;
-                }
-            });
-
-            if (!hasTeeData) {
-                const teeError = new TeeVerificationError('TEE verification requested but one or more proofs are missing TEE attestation data');
-                logger.error(teeError.message);
-                return createVerifyProofResultFailure(teeError, false);
-            }
-
-            try {
-                const { appSecret } = config.teeAttestation;
-                const appId = new ethers.Wallet(appSecret).address;
-                const teeResults = await Promise.all(
-                    proofs.map(proof => verifyTeeAttestation(proof, appId, appSecret))
-                );
-                isTeeVerified = teeResults.every(r => r.isVerified);
-                if (!isTeeVerified) {
-                    const teeError = new TeeVerificationError('TEE attestation verification failed for one or more proofs');
-                    logger.error(teeError.message);
-                    return createVerifyProofResultFailure(teeError, false);
-                }
-            } catch (error) {
-                const teeError = new TeeVerificationError('Error verifying TEE attestation', error);
-                logger.error(teeError.message);
-                return createVerifyProofResultFailure(teeError, false);
-            }
+            await runTeeVerification(proofs, config.teeAttestation);
+            isTeeVerified = true;
         }
 
         return createVerifyProofResultSuccess(proofs, isTeeVerified);

--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -48,6 +48,7 @@ import { assertVerifiedProof, createLinkWithTemplateData, getAttestors } from '.
 import { QRCodeModal } from './utils/modalUtils'
 import loggerModule from './utils/logger';
 import { getDeviceType, getMobileDeviceType } from './utils/device'
+import { generateAttestationNonce } from './utils/attestationNonce'
 import { canonicalStringify } from './utils/strings'
 import { assertValidateProof, VerificationConfig } from './utils/proofValidationUtils'
 import { verifyTeeAttestation } from './utils/verifyTee'
@@ -149,7 +150,9 @@ export async function verifyProof(
             }
 
             try {
-                const teeResults = await Promise.all(proofs.map(proof => verifyTeeAttestation(proof)));
+                const teeResults = await Promise.all(
+                    proofs.map(proof => verifyTeeAttestation(proof, undefined, config.teeVerificationSecret))
+                );
                 isTeeVerified = teeResults.every(r => r === true);
                 if (!isTeeVerified) {
                     const teeError = new TeeVerificationError('TEE attestation verification failed for one or more proofs');
@@ -431,12 +434,14 @@ export class ReclaimProofRequest {
             proofRequestInstance.context.reclaimSessionId = data.sessionId
 
             if (options?.acceptTeeAttestation) {
-                const wallet = new ethers.Wallet(appSecret)
-                const nonceData = `${applicationId}:${data.sessionId}:${proofRequestInstance.timeStamp}`
-                const nonceMsg = ethers.getBytes(ethers.keccak256(new TextEncoder().encode(nonceData)))
-                const nonceSignature = await wallet.signMessage(nonceMsg)
+                const attestationNonce = generateAttestationNonce(
+                    appSecret,
+                    applicationId,
+                    data.sessionId,
+                    proofRequestInstance.timeStamp
+                )
 
-                proofRequestInstance.setAttestationContext(nonceSignature, {
+                proofRequestInstance.setAttestationContext(attestationNonce, {
                     applicationId,
                     sessionId: data.sessionId,
                     timestamp: proofRequestInstance.timeStamp

--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -70,8 +70,8 @@ const sdkVersion = require('../package.json').version;
  * * All 3 functions above are alternatives of each other and result from these functions can be directly used as `config` parameter in this function for proof validation.
  *
  * @param proofOrProofs - A single proof object or an array of proof objects to be verified.
- * @param config - Verification configuration that specifies required hashes, allowed extra hashes, or disables content validation. Optionally includes `verifyTEE` to require TEE attestation verification.
- * @returns Verification result with `isVerified`, extracted `data` from each proof, optional `error` on failure, and `isTeeVerified` when `verifyTEE` is enabled.
+ * @param config - Verification configuration that specifies required hashes, allowed extra hashes, or disables content validation. Optionally includes `teeAttestation` to require TEE attestation verification.
+ * @returns Verification result with `isVerified`, extracted `data` from each proof, optional `error` on failure, and `isTeeVerified` when `teeAttestation` is provided.
  *
  * @example
  * ```typescript
@@ -79,7 +79,7 @@ const sdkVersion = require('../package.json').version;
  * const { isVerified, data } = await verifyProof(proof, request.getProviderVersion());
  *
  * // With TEE attestation verification (fails if TEE data is missing or invalid)
- * const { isVerified, isTeeVerified, data } = await verifyProof(proof, { ...request.getProviderVersion(), verifyTEE: true });
+ * const { isVerified, isTeeVerified, data } = await verifyProof(proof, { ...request.getProviderVersion(), teeAttestation: { appSecret: APP_SECRET } });
  * 
  * // Or, by manually providing the details:
  * 
@@ -138,10 +138,22 @@ export async function verifyProof(
 
         await assertValidateProof(proofs, config);
 
-        let isTeeVerified: boolean | undefined = undefined;
+        let isTeeVerified = false;
 
-        if (config.verifyTEE) {
-            const hasTeeData = proofs.every(proof => proof.teeAttestation || JSON.parse(proof.claimData.context).attestationNonce);
+        if (config.teeAttestation && 'dangerouslyDisableContentValidation' in config) {
+            logger.warn('teeAttestation is enabled but content validation is disabled — TEE attestation alone does not guarantee proof contents are valid');
+        }
+
+        if (config.teeAttestation) {
+            const hasTeeData = proofs.every(proof => {
+                if (proof.teeAttestation) return true;
+                try {
+                    const context = JSON.parse(proof.claimData.context);
+                    return !!context?.attestationNonce;
+                } catch {
+                    return false;
+                }
+            });
 
             if (!hasTeeData) {
                 const teeError = new TeeVerificationError('TEE verification requested but one or more proofs are missing TEE attestation data');
@@ -150,10 +162,12 @@ export async function verifyProof(
             }
 
             try {
+                const { appSecret } = config.teeAttestation;
+                const appId = new ethers.Wallet(appSecret).address;
                 const teeResults = await Promise.all(
-                    proofs.map(proof => verifyTeeAttestation(proof, undefined, config.teeVerificationSecret))
+                    proofs.map(proof => verifyTeeAttestation(proof, appId, appSecret))
                 );
-                isTeeVerified = teeResults.every(r => r === true);
+                isTeeVerified = teeResults.every(r => r.isVerified);
                 if (!isTeeVerified) {
                     const teeError = new TeeVerificationError('TEE attestation verification failed for one or more proofs');
                     logger.error(teeError.message);

--- a/src/__tests__/verify_proof.test.ts
+++ b/src/__tests__/verify_proof.test.ts
@@ -2,19 +2,211 @@
  * @jest-environment node
  */
 
+import { createHash, createSign, generateKeyPairSync } from 'crypto';
+import { ethers } from 'ethers';
 import { verifyProof, verifyTeeAttestation, TeeVerificationError } from '../index';
 import { getPublicDataFromProofs } from '../utils/helper';
 import { Proof, TeeAttestation } from '../utils/interfaces';
+import { ATTESTATION_NONCE_DOMAIN, generateAttestationNonce } from '../utils/attestationNonce';
 
-const proofData = [{ "identifier": "0xbb5c63656a650276728d3cb9ce3f90361223c7814fd94f6582b682dfc96e4ba8", "claimData": { "provider": "http", "parameters": "{\"additionalClientOptions\":{\"popcornApiUrl\":\"https://popcorn-cluster-aws-us-east-2.popcorn.reclaimprotocol.org\"},\"body\":\"{\\\"includeGroups\\\":false,\\\"includeLogins\\\":false,\\\"includeVerificationStatus\\\":true}\",\"geoLocation\":\"{{DYNAMIC_GEO}}\",\"headers\":{\"Accept\":\"application/json\",\"Accept-Language\":\"en-US,en;q=0.9\",\"Sec-Ch-Ua\":\"\\\"Not-A.Brand\\\";v=\\\"24\\\", \\\"Chromium\\\";v=\\\"146\\\"\",\"Sec-Ch-Ua-Mobile\":\"?0\",\"Sec-Fetch-Mode\":\"same-origin\",\"Sec-Fetch-Site\":\"same-origin\",\"User-Agent\":\"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36\"},\"method\":\"POST\",\"paramValues\":{\"DYNAMIC_GEO\":\"IN\",\"username\":\"srivatsanqb\"},\"proxySessionId\":\"1ab031c2ef\",\"responseMatches\":[{\"type\":\"contains\",\"value\":\"\\\"userName\\\":\\\"{{username}}\\\"\"}],\"responseRedactions\":[{\"jsonPath\":\"$.userName\",\"regex\":\"\\\"userName\\\":\\\"(.*)\\\"\",\"xPath\":\"\"}],\"url\":\"https://www.kaggle.com/api/i/users.UsersService/GetCurrentUser\"}", "owner": "0x9c3dcb81fe10f6e494bfaa0220ea0ba7bcf3ad94", "timestampS": 1774346626, "context": "{\"attestationNonce\":\"0xdf1cd84efbeded8c07d0fcdccc4883e74ecf5ed65eaf023d2aa1aafd75611f6c04eb1f633396ecbcc4f6fe9fc11c25586a4dac3a99deb40c44ae5cf49cebae6d1b\",\"attestationNonceData\":{\"applicationId\":\"0xd116D518eacea61C7af9760E5d8D1b720a0CE8D5\",\"sessionId\":\"1ab031c2ef\",\"timestamp\":\"1774346557104\"},\"contextAddress\":\"0x0\",\"contextMessage\":\"sample context\",\"extractedParameters\":{\"DYNAMIC_GEO\":\"IN\",\"username\":\"srivatsanqb\"},\"providerHash\":\"0x4c20776ae89ab7eead49e4e393f4e07348a4d85e21869201aa6eea6e2bc07f5b\",\"reclaimSessionId\":\"1ab031c2ef\"}", "identifier": "0xbb5c63656a650276728d3cb9ce3f90361223c7814fd94f6582b682dfc96e4ba8", "epoch": 1 }, "witnesses": [{ "id": "0x244897572368eadf65bfbc5aec98d8e5443a9072", "url": "wss://attestor.reclaimprotocol.org:444/ws" }], "signatures": ["0x379b164165e005d75be4ec7854d745d68ad56d738a08da3a4c30eb071948bf5d0c7262bb8c46189e0cadb583dbb00917b73fbdbf74b5914eb69774ce97196a911c"], "teeAttestation": { "workload_digest": "342772716647.dkr.ecr.us-east-2.amazonaws.com/popcorn/browser-node@sha256:beb71484ef0fa21e0fbe204e2522a012fa16d6b4be4b4fcb1d9b13727d48188b", "verifier_digest": "342772716647.dkr.ecr.us-east-2.amazonaws.com/popcorn/attestor@sha256:41ca800a1fc851d60a8885c7b87d9481565484512b47c5bf1badb43243855bca", "nonce": "0xdf1cd84efbeded8c07d0fcdccc4883e74ecf5ed65eaf023d2aa1aafd75611f6c04eb1f633396ecbcc4f6fe9fc11c25586a4dac3a99deb40c44ae5cf49cebae6d1b", "snp_report": "BQAAAAAAAAAAAAMCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAEAAAAEAAAAAAAd3icAAAAAAAAABAAAAAAAAADHYrIWCfikwvPs/dRPK5XYtt5cYfLfHfK2ZoX+YLExwMdishYJ+KTC8+z91E8rldi23lxh8t8d8rZmhf5gsTHAt1bd5yxUjkJWC6a0OVW2jBI5aCEEx4+geYntPRVHgQfLDgoqljdgRYa5YV642nYXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACrXDTSvTs8rMd6eJVyxntdx8BBmmPvCo00o6mpM/Oo6///////////////////////////////////////////BAAAAAAAHd4ZAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAHd4BOgEAAToBAAQAAAAAAB3eDwAAAAAAAAAPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxb6iyCGN6w1+riXkbH/VRo74O7renVbzgEV55dDfppNSQch0oHVzSkdkof7cutCuAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA883WWYbGmUblVREZjknNOVNHOAocli+JJ/RLttazCHVOQnMxItPJxuNpXown66H7AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", "vlek_cert": "MIIFIzCCAtegAwIBAgIBADBBBgkqhkiG9w0BAQowNKAPMA0GCWCGSAFlAwQCAgUAoRwwGgYJKoZIhvcNAQEIMA0GCWCGSAFlAwQCAgUAogMCATAwgYAxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQswCQYDVQQGEwJVUzEUMBIGA1UEBwwLU2FudGEgQ2xhcmExCzAJBgNVBAgMAkNBMR8wHQYDVQQKDBZBZHZhbmNlZCBNaWNybyBEZXZpY2VzMRcwFQYDVQQDDA5TRVYtVkxFSy1NaWxhbjAeFw0yNjAzMDkxOTMwMDVaFw0yNzAzMDkxOTMwMDVaMHoxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQswCQYDVQQGEwJVUzEUMBIGA1UEBwwLU2FudGEgQ2xhcmExCzAJBgNVBAgMAkNBMR8wHQYDVQQKDBZBZHZhbmNlZCBNaWNybyBEZXZpY2VzMREwDwYDVQQDDAhTRVYtVkxFSzB2MBAGByqGSM49AgEGBSuBBAAiA2IABE/rO0PxEkKVu5SAX9Fv+h1pF0r+wWNmNO+DLcMENz2IOaqYiS6swJjXThFjsjIx5mdy42ozh33DIC+b02LmGScVQrREUL0h5KR4Qd5+BTiO+UDBb8Xd/p8rzpTQn+foEKOB8jCB7zAQBgkrBgEEAZx4AQEEAwIBADAUBgkrBgEEAZx4AQIEBxYFTWlsYW4wEQYKKwYBBAGceAEDAQQDAgEEMBEGCisGAQQBnHgBAwIEAwIBADARBgorBgEEAZx4AQMEBAMCAQAwEQYKKwYBBAGceAEDBQQDAgEAMBEGCisGAQQBnHgBAwYEAwIBADARBgorBgEEAZx4AQMHBAMCAQAwEQYKKwYBBAGceAEDAwQDAgEdMBIGCisGAQQBnHgBAwgEBAICAN4wLAYJKwYBBAGceAEFBB8WHUNOPWNjLXVzLWVhc3QtMi5hbWF6b25hd3MuY29tMEEGCSqGSIb3DQEBCjA0oA8wDQYJYIZIAWUDBAICBQChHDAaBgkqhkiG9w0BAQgwDQYJYIZIAWUDBAICBQCiAwIBMAOCAgEAezLRKlKoxDhJ9gGLDoIhruKSWJcwMHPn6E/aJzJvpDaYfb12ACKHyiMsm5htk6+lL9Kse544pmhhUm/hxlpUNXiF+61obfKcaxp11Q2hzC/hTyLYpse6IXskLq6OH+DXzrcw0X30t3YIiUqzCGszbeTBy4uUOULxz3XbSUYFsKwsk9oMuo7isOUM3INiMiOTq91THlp6ZSVJDLIpW8v17DSL7yfJsvyLKsvtL7YjohFsOJe/qr/ttVSLC9WJmnxMxaxtgLSVGwCNTHsx6646R7SAPRVXpdOd4f+Gfj4Dk1eiELs1L85Qm0tChDLrLLO31X9cwPxg6fjdZ3sgqZrOv9Up2EiiX3uzH9pjuek9KZw8BvbNmkABURnj2QVKkANKWeVwJ2OI9xmbKnLDQp+t3Q6gTcdPdcjSsAkT0JijpzamEmIPLdBobgVHAcxCxRhBILmJWQcU8V8Rg2+n/Zs8gpuGaCj0j8s8YDq7+sgy0/5CsDgAhU7+4HqzBTPbhOCNAI9uptU6v0xoDLzldXmVJQaGWp6zQ+WB29ZnFrF4UE85+os3uIwc6uEPBjh3bjmhTwa3I7LWRWldRyoJUuLnBIdTJYVIkgrYJ47LfI3akZxUM0D+FpqawemnHOTT1z8ee1wj7wnE6nS2X0R7cJNthweU48At2ZfRIuPYvu9av2Y=", "timestamp": "2026-03-24T10:03:43Z" } }]
+const GCP_ISSUER = 'https://confidentialcomputing.googleapis.com';
+const GCP_OIDC_URL = `${GCP_ISSUER}/.well-known/openid-configuration`;
+const GCP_JWKS_URL = `${GCP_ISSUER}/jwks`;
+const TEST_TEE_SECRET = 'test-app-secret';
+const expectedApplicationId = '0xd116D518eacea61C7af9760E5d8D1b720a0CE8D5';
+const workloadDigest = 'us-docker.pkg.dev/rc-popcorn/popcorn-images/browser-node@sha256:97d4656f457831cf540b80a85daac40dcfa2f618beffcf3dd5966023ad8cab14';
+const verifierDigest = 'us-docker.pkg.dev/rc-popcorn/popcorn-images/attestor@sha256:acaa00688de4ce0517303172fc89efd085c6e1a9647ca50066353eba6b8cc228';
 
-const expectedApplicationId = "0xd116D518eacea61C7af9760E5d8D1b720a0CE8D5";
+const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+const publicJwk = publicKey.export({ format: 'jwk' }) as JsonWebKey;
+const gcpJwk = {
+    ...publicJwk,
+    kid: 'test-gcp-kid',
+    alg: 'RS256',
+    use: 'sig',
+};
+
+const baseProofData: Proof = {
+    identifier: '0xbb5c63656a650276728d3cb9ce3f90361223c7814fd94f6582b682dfc96e4ba8',
+    claimData: {
+        provider: 'http',
+        parameters: '{"additionalClientOptions":{"popcornApiUrl":"https://popcorn-cluster-aws-us-east-2.popcorn.reclaimprotocol.org"},"body":"{\\"includeGroups\\":false,\\"includeLogins\\":false,\\"includeVerificationStatus\\":true}","geoLocation":"{{DYNAMIC_GEO}}","headers":{"Accept":"application/json","Accept-Language":"en-US,en;q=0.9","Sec-Ch-Ua":"\\"Not-A.Brand\\";v=\\"24\\", \\"Chromium\\";v=\\"146\\"","Sec-Ch-Ua-Mobile":"?0","Sec-Fetch-Mode":"same-origin","Sec-Fetch-Site":"same-origin","User-Agent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36"},"method":"POST","paramValues":{"DYNAMIC_GEO":"IN","username":"srivatsanqb"},"proxySessionId":"1ab031c2ef","responseMatches":[{"type":"contains","value":"\\"userName\\":\\"{{username}}\\""}],"responseRedactions":[{"jsonPath":"$.userName","regex":"\\"userName\\":\\"(.*)\\"","xPath":""}],"url":"https://www.kaggle.com/api/i/users.UsersService/GetCurrentUser"}',
+        owner: '0x9c3dcb81fe10f6e494bfaa0220ea0ba7bcf3ad94',
+        timestampS: 1774346626,
+        context: '{"attestationNonce":"0xdf1cd84efbeded8c07d0fcdccc4883e74ecf5ed65eaf023d2aa1aafd75611f6c04eb1f633396ecbcc4f6fe9fc11c25586a4dac3a99deb40c44ae5cf49cebae6d1b","attestationNonceData":{"applicationId":"0xd116D518eacea61C7af9760E5d8D1b720a0CE8D5","sessionId":"1ab031c2ef","timestamp":"1774346557104"},"contextAddress":"0x0","contextMessage":"sample context","extractedParameters":{"DYNAMIC_GEO":"IN","username":"srivatsanqb"},"providerHash":"0x4c20776ae89ab7eead49e4e393f4e07348a4d85e21869201aa6eea6e2bc07f5b","reclaimSessionId":"1ab031c2ef"}',
+        identifier: '0xbb5c63656a650276728d3cb9ce3f90361223c7814fd94f6582b682dfc96e4ba8',
+        epoch: 1,
+    },
+    witnesses: [
+        {
+            id: '0x244897572368eadf65bfbc5aec98d8e5443a9072',
+            url: 'wss://attestor.reclaimprotocol.org:444/ws',
+        },
+    ],
+    signatures: [
+        '0x379b164165e005d75be4ec7854d745d68ad56d738a08da3a4c30eb071948bf5d0c7262bb8c46189e0cadb583dbb00917b73fbdbf74b5914eb69774ce97196a911c',
+    ],
+    extractedParameterValues: undefined,
+};
 
 function cloneProof(): Proof {
-    return JSON.parse(JSON.stringify(proofData[0])) as Proof;
+    return JSON.parse(JSON.stringify(baseProofData)) as Proof;
 }
 
+function createFetchResponse(body: any, status = 200) {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: status === 200 ? 'OK' : 'ERROR',
+        json: async () => body,
+    };
+}
+
+function base64UrlEncode(input: Buffer | string): string {
+    const buffer = Buffer.isBuffer(input) ? input : Buffer.from(input);
+    return buffer.toString('base64url');
+}
+
+function signJwt(payload: Record<string, any>): string {
+    const header = { alg: 'RS256', kid: gcpJwk.kid, typ: 'JWT' };
+    const signingInput = `${base64UrlEncode(JSON.stringify(header))}.${base64UrlEncode(JSON.stringify(payload))}`;
+    const signer = createSign('RSA-SHA256');
+    signer.update(signingInput);
+    signer.end();
+    const signature = signer.sign(privateKey).toString('base64url');
+    return `${signingInput}.${signature}`;
+}
+
+function createDigestBinding(workloadImageDigest: string, verifierImageDigest: string): string {
+    return createHash('sha256')
+        .update(`${workloadImageDigest}\n${verifierImageDigest}`)
+        .digest('hex');
+}
+
+function createGcpTeeAttestation(
+    nonce: string,
+    overrides: Partial<TeeAttestation> = {},
+    claimsOverrides: Record<string, any> = {}
+): TeeAttestation {
+    const now = Math.floor(Date.now() / 1000);
+    const nextWorkloadDigest = overrides.workload?.image_digest ?? workloadDigest;
+    const nextVerifierDigest = overrides.verifier?.image_digest ?? verifierDigest;
+
+    const token = signJwt({
+        aud: 'https://unit-test.popcorn.reclaimprotocol.org',
+        exp: now + 3600,
+        iat: now - 10,
+        iss: GCP_ISSUER,
+        nbf: now - 10,
+        sub: 'https://www.googleapis.com/compute/v1/projects/rc-popcorn/zones/asia-south1-c/instances/test-instance',
+        eat_nonce: [nonce, createDigestBinding(nextWorkloadDigest, nextVerifierDigest)],
+        hwmodel: 'GCP_AMD_SEV',
+        secboot: true,
+        submods: {
+            gce: {
+                project_id: 'rc-popcorn',
+                zone: 'asia-south1-c',
+                instance_name: 'test-instance',
+            },
+        },
+        ...claimsOverrides,
+    });
+
+    return {
+        proof_version: 'v2',
+        tee_provider: 'gcp',
+        tee_technology: 'amd-sev',
+        nonce,
+        timestamp: new Date().toISOString(),
+        workload: {
+            container_name: 'neko',
+            image_digest: nextWorkloadDigest,
+        },
+        verifier: {
+            container_name: 'attestor',
+            image_digest: nextVerifierDigest,
+        },
+        attestation: { token },
+        ...overrides,
+    };
+}
+
+function attachLegacyNonceTeeAttestation(proof: Proof): TeeAttestation {
+    const context = JSON.parse(proof.claimData.context);
+    const teeAttestation = createGcpTeeAttestation(context.attestationNonce);
+    proof.teeAttestation = teeAttestation;
+    return teeAttestation;
+}
+
+function attachHashNonceTeeAttestation(proof: Proof, secret = TEST_TEE_SECRET): TeeAttestation {
+    const context = JSON.parse(proof.claimData.context);
+    const { applicationId, sessionId, timestamp } = context.attestationNonceData;
+    const attestationNonce = generateAttestationNonce(secret, applicationId, sessionId, timestamp);
+
+    context.attestationNonce = attestationNonce;
+    proof.claimData.context = JSON.stringify(context);
+
+    const teeAttestation = createGcpTeeAttestation(attestationNonce);
+    proof.teeAttestation = teeAttestation;
+    return teeAttestation;
+}
+
+describe('generateAttestationNonce', () => {
+    it('returns a 64-character hex nonce without leaking the app secret', () => {
+        const appSecret = 'test-app-secret';
+        const nonce = generateAttestationNonce(
+            appSecret,
+            'app-id',
+            'session-id',
+            '1712759999000'
+        );
+
+        expect(nonce).toMatch(/^[a-f0-9]{64}$/);
+        expect(nonce).not.toContain(appSecret);
+    });
+
+    it('uses domain separation in the nonce payload', () => {
+        const appSecret = 'test-app-secret';
+        const applicationId = 'app-id';
+        const sessionId = 'session-id';
+        const timestamp = '1712759999000';
+        const nonce = generateAttestationNonce(appSecret, applicationId, sessionId, timestamp);
+        const undomainedNonce = ethers.keccak256(
+            ethers.toUtf8Bytes(`${applicationId}:${sessionId}:${timestamp}:${appSecret}`)
+        ).replace(/^0x/i, '');
+
+        expect(nonce).not.toBe(undomainedNonce);
+        expect(nonce).toBe(
+            ethers.keccak256(
+                ethers.toUtf8Bytes(
+                    `${ATTESTATION_NONCE_DOMAIN}:${applicationId}:${sessionId}:${timestamp}:${appSecret}`
+                )
+            ).replace(/^0x/i, '')
+        );
+    });
+});
+
 describe('verifyProof', () => {
+    const originalFetch = global.fetch;
+
+    beforeAll(() => {
+        global.fetch = jest.fn(async (input: any, init?: any) => {
+            const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input?.url;
+
+            if (url === GCP_OIDC_URL) {
+                return createFetchResponse({ jwks_uri: GCP_JWKS_URL }) as any;
+            }
+            if (url === GCP_JWKS_URL) {
+                return createFetchResponse({ keys: [gcpJwk] }) as any;
+            }
+            return originalFetch(input, init);
+        }) as typeof fetch;
+    });
+
+    afterAll(() => {
+        global.fetch = originalFetch;
+    });
+
     it('verifies proof signature and returns extracted data', async () => {
         const proof = cloneProof();
         const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true });
@@ -44,11 +236,9 @@ describe('verifyProof', () => {
 
     it('returns TeeVerificationError when TEE digests are tampered', async () => {
         const proof = cloneProof();
-        const attestation = proof.teeAttestation as TeeAttestation;
-        const [prefix, digest] = attestation.workload_digest.split('@sha256:');
-        const originalHex = digest ?? '';
-        const flippedHex = (originalHex[0] === '0' ? '1' : '0') + originalHex.slice(1);
-        attestation.workload_digest = `${prefix}@sha256:${flippedHex}`;
+        const attestation = attachLegacyNonceTeeAttestation(proof);
+        attestation.workload.image_digest = `us-docker.pkg.dev/rc-popcorn/popcorn-images/browser-node@sha256:${'1'.repeat(64)}`;
+
         const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true, verifyTEE: true });
         expect(result.isVerified).toBe(false);
         expect(result.isTeeVerified).toBe(false);
@@ -58,8 +248,7 @@ describe('verifyProof', () => {
     it('returns TeeVerificationError when teeAttestation is missing from proof', async () => {
         const proof = cloneProof();
         delete (proof as any).teeAttestation;
-        // Context (and its attestationNonce) stays intact so signature remains valid.
-        // verifyTeeAttestation sees missing teeAttestation and returns false.
+
         const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true, verifyTEE: true });
         expect(result.isVerified).toBe(false);
         expect(result.isTeeVerified).toBe(false);
@@ -68,12 +257,87 @@ describe('verifyProof', () => {
 
     it('standalone verifyTeeAttestation detects tampered digests', async () => {
         const proof = cloneProof();
-        const attestation = proof.teeAttestation as TeeAttestation;
-        const [prefix, digest] = attestation.workload_digest.split('@sha256:');
-        const originalHex = digest ?? '';
-        const flippedHex = (originalHex[0] === '0' ? '1' : '0') + originalHex.slice(1);
-        attestation.workload_digest = `${prefix}@sha256:${flippedHex}`;
+        const attestation = attachLegacyNonceTeeAttestation(proof);
+        attestation.workload.image_digest = `us-docker.pkg.dev/rc-popcorn/popcorn-images/browser-node@sha256:${'2'.repeat(64)}`;
+
         await expect(verifyTeeAttestation(proof, expectedApplicationId)).resolves.toBe(false);
+    });
+
+    it('verifies a valid GCP TEE attestation when the hash-based nonce secret is provided', async () => {
+        const proof = cloneProof();
+        attachHashNonceTeeAttestation(proof);
+
+        await expect(
+            verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET)
+        ).resolves.toBe(true);
+    });
+
+    it('fails hash-based nonce verification when the verifier does not provide the app secret', async () => {
+        const proof = cloneProof();
+        attachHashNonceTeeAttestation(proof);
+
+        await expect(verifyTeeAttestation(proof, expectedApplicationId)).resolves.toBe(false);
+    });
+
+    it('fails hash-based nonce verification when the verifier provides the wrong app secret', async () => {
+        const proof = cloneProof();
+        attachHashNonceTeeAttestation(proof);
+
+        await expect(verifyTeeAttestation(proof, expectedApplicationId, 'wrong-secret')).resolves.toBe(false);
+    });
+
+    it('fails when the nonce is valid but generated for a different session', async () => {
+        const proof = cloneProof();
+        const context = JSON.parse(proof.claimData.context);
+        const { applicationId, timestamp } = context.attestationNonceData;
+        const differentSessionId = '058b771dbc';
+        const differentSessionNonce = generateAttestationNonce(
+            TEST_TEE_SECRET,
+            applicationId,
+            differentSessionId,
+            timestamp
+        );
+
+        // Keep the proof session binding unchanged, but swap in a nonce that is
+        // cryptographically valid for another session ID.
+        context.attestationNonce = differentSessionNonce;
+        proof.claimData.context = JSON.stringify(context);
+        proof.teeAttestation = createGcpTeeAttestation(differentSessionNonce);
+
+        await expect(
+            verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET)
+        ).resolves.toBe(false);
+    });
+
+    it('throws immediately when TEE verification is invoked in a browser-like environment', async () => {
+        const proof = cloneProof();
+        attachHashNonceTeeAttestation(proof);
+
+        const originalWindow = (globalThis as any).window;
+        const originalDocument = (globalThis as any).document;
+
+        try {
+            (globalThis as any).window = {};
+            (globalThis as any).document = {};
+
+            await expect(
+                verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET)
+            ).rejects.toThrow(
+                'TEE attestation verification is only supported in non-browser environments'
+            );
+        } finally {
+            if (typeof originalWindow === 'undefined') {
+                delete (globalThis as any).window;
+            } else {
+                (globalThis as any).window = originalWindow;
+            }
+
+            if (typeof originalDocument === 'undefined') {
+                delete (globalThis as any).document;
+            } else {
+                (globalThis as any).document = originalDocument;
+            }
+        }
     });
 });
 
@@ -100,7 +364,6 @@ describe('getPublicDataFromProofs', () => {
         const proof1 = cloneProof();
         const proof2 = cloneProof();
         proof1.publicData = { user: 'test', score: '100' };
-        // Identical data but different key order to also test canonical hashing
         proof2.publicData = { score: '100', user: 'test' };
 
         const result = getPublicDataFromProofs([proof1, proof2]);

--- a/src/__tests__/verify_proof.test.ts
+++ b/src/__tests__/verify_proof.test.ts
@@ -216,17 +216,17 @@ describe('verifyProof', () => {
         const proof = cloneProof();
         const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true });
         expect(result.isVerified).toBe(true);
-        expect(result.isTeeVerified).toBe(false);
+        expect(result.isTeeAttestationVerified).toBeUndefined();
         expect(result.error).toBeUndefined();
         expect(result.data).toHaveLength(1);
         expect(result.data[0].extractedParameters).toEqual({ DYNAMIC_GEO: 'IN', username: 'srivatsanqb' });
     });
 
-    it('returns isTeeVerified as false when teeAttestation is not requested', async () => {
+    it('returns isTeeAttestationVerified as undefined when teeAttestation is not requested', async () => {
         const proof = cloneProof();
         const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true });
         expect(result.isVerified).toBe(true);
-        expect(result.isTeeVerified).toBe(false);
+        expect(result.isTeeAttestationVerified).toBeUndefined();
     });
 
     it('returns error object when signature verification fails', async () => {
@@ -234,7 +234,7 @@ describe('verifyProof', () => {
         proof.signatures = ['0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ff'];
         const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true });
         expect(result.isVerified).toBe(false);
-        expect(result.isTeeVerified).toBe(false);
+        expect(result.isTeeAttestationVerified).toBeUndefined();
         expect(result.error).toBeInstanceOf(Error);
         expect(result.data).toEqual([]);
     });
@@ -244,7 +244,7 @@ describe('verifyProof', () => {
         proof.claimData.timestampS = proof.claimData.timestampS + 60 * 60;
         const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true });
         expect(result.isVerified).toBe(false);
-        expect(result.isTeeVerified).toBe(false);
+        expect(result.isTeeAttestationVerified).toBeUndefined();
         expect(result.error).toBeInstanceOf(Error);
         expect(result.data).toEqual([]);
     });
@@ -256,7 +256,7 @@ describe('verifyProof', () => {
 
         const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true, teeAttestation: { appSecret: TEST_APP_SECRET } });
         expect(result.isVerified).toBe(false);
-        expect(result.isTeeVerified).toBe(false);
+        expect(result.isTeeAttestationVerified).toBeUndefined();
         expect(result.error).toBeInstanceOf(TeeVerificationError);
     });
 
@@ -266,7 +266,7 @@ describe('verifyProof', () => {
 
         const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true, teeAttestation: { appSecret: TEST_APP_SECRET } });
         expect(result.isVerified).toBe(false);
-        expect(result.isTeeVerified).toBe(false);
+        expect(result.isTeeAttestationVerified).toBeUndefined();
         expect(result.error).toBeInstanceOf(TeeVerificationError);
     });
 

--- a/src/__tests__/verify_proof.test.ts
+++ b/src/__tests__/verify_proof.test.ts
@@ -12,7 +12,8 @@ import { ATTESTATION_NONCE_DOMAIN, generateAttestationNonce } from '../utils/att
 const GCP_ISSUER = 'https://confidentialcomputing.googleapis.com';
 const GCP_OIDC_URL = `${GCP_ISSUER}/.well-known/openid-configuration`;
 const GCP_JWKS_URL = `${GCP_ISSUER}/jwks`;
-const TEST_TEE_SECRET = 'test-app-secret';
+const TEST_TEE_SECRET = '0x49becaaf6bfe2472943302c64b7b2b6295a0ca5e28481bb6dc7c075d4dd50f82';
+const TEST_APP_SECRET = TEST_TEE_SECRET;
 const expectedApplicationId = '0xd116D518eacea61C7af9760E5d8D1b720a0CE8D5';
 const workloadDigest = 'us-docker.pkg.dev/rc-popcorn/popcorn-images/browser-node@sha256:97d4656f457831cf540b80a85daac40dcfa2f618beffcf3dd5966023ad8cab14';
 const verifierDigest = 'us-docker.pkg.dev/rc-popcorn/popcorn-images/attestor@sha256:acaa00688de4ce0517303172fc89efd085c6e1a9647ca50066353eba6b8cc228';
@@ -211,9 +212,17 @@ describe('verifyProof', () => {
         const proof = cloneProof();
         const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true });
         expect(result.isVerified).toBe(true);
+        expect(result.isTeeVerified).toBe(false);
         expect(result.error).toBeUndefined();
         expect(result.data).toHaveLength(1);
         expect(result.data[0].extractedParameters).toEqual({ DYNAMIC_GEO: 'IN', username: 'srivatsanqb' });
+    });
+
+    it('returns isTeeVerified as false when teeAttestation is not requested', async () => {
+        const proof = cloneProof();
+        const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true });
+        expect(result.isVerified).toBe(true);
+        expect(result.isTeeVerified).toBe(false);
     });
 
     it('returns error object when signature verification fails', async () => {
@@ -221,6 +230,7 @@ describe('verifyProof', () => {
         proof.signatures = ['0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ff'];
         const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true });
         expect(result.isVerified).toBe(false);
+        expect(result.isTeeVerified).toBe(false);
         expect(result.error).toBeInstanceOf(Error);
         expect(result.data).toEqual([]);
     });
@@ -230,6 +240,7 @@ describe('verifyProof', () => {
         proof.claimData.timestampS = proof.claimData.timestampS + 60 * 60;
         const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true });
         expect(result.isVerified).toBe(false);
+        expect(result.isTeeVerified).toBe(false);
         expect(result.error).toBeInstanceOf(Error);
         expect(result.data).toEqual([]);
     });
@@ -239,7 +250,7 @@ describe('verifyProof', () => {
         const attestation = attachLegacyNonceTeeAttestation(proof);
         attestation.workload.image_digest = `us-docker.pkg.dev/rc-popcorn/popcorn-images/browser-node@sha256:${'1'.repeat(64)}`;
 
-        const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true, verifyTEE: true });
+        const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true, teeAttestation: { appSecret: TEST_APP_SECRET } });
         expect(result.isVerified).toBe(false);
         expect(result.isTeeVerified).toBe(false);
         expect(result.error).toBeInstanceOf(TeeVerificationError);
@@ -249,7 +260,7 @@ describe('verifyProof', () => {
         const proof = cloneProof();
         delete (proof as any).teeAttestation;
 
-        const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true, verifyTEE: true });
+        const result = await verifyProof(proof, { dangerouslyDisableContentValidation: true, teeAttestation: { appSecret: TEST_APP_SECRET } });
         expect(result.isVerified).toBe(false);
         expect(result.isTeeVerified).toBe(false);
         expect(result.error).toBeInstanceOf(TeeVerificationError);
@@ -260,30 +271,36 @@ describe('verifyProof', () => {
         const attestation = attachLegacyNonceTeeAttestation(proof);
         attestation.workload.image_digest = `us-docker.pkg.dev/rc-popcorn/popcorn-images/browser-node@sha256:${'2'.repeat(64)}`;
 
-        await expect(verifyTeeAttestation(proof, expectedApplicationId)).resolves.toBe(false);
+        const result = await verifyTeeAttestation(proof, expectedApplicationId);
+        expect(result.isVerified).toBe(false);
+        expect(typeof result.error).toBe('string');
     });
 
     it('verifies a valid GCP TEE attestation when the hash-based nonce secret is provided', async () => {
         const proof = cloneProof();
         attachHashNonceTeeAttestation(proof);
 
-        await expect(
-            verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET)
-        ).resolves.toBe(true);
+        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        expect(result.isVerified).toBe(true);
+        expect(result.error).toBeUndefined();
     });
 
     it('fails hash-based nonce verification when the verifier does not provide the app secret', async () => {
         const proof = cloneProof();
         attachHashNonceTeeAttestation(proof);
 
-        await expect(verifyTeeAttestation(proof, expectedApplicationId)).resolves.toBe(false);
+        const result = await verifyTeeAttestation(proof, expectedApplicationId);
+        expect(result.isVerified).toBe(false);
+        expect(typeof result.error).toBe('string');
     });
 
     it('fails hash-based nonce verification when the verifier provides the wrong app secret', async () => {
         const proof = cloneProof();
         attachHashNonceTeeAttestation(proof);
 
-        await expect(verifyTeeAttestation(proof, expectedApplicationId, 'wrong-secret')).resolves.toBe(false);
+        const result = await verifyTeeAttestation(proof, expectedApplicationId, 'wrong-secret');
+        expect(result.isVerified).toBe(false);
+        expect(typeof result.error).toBe('string');
     });
 
     it('fails when the nonce is valid but generated for a different session', async () => {
@@ -304,9 +321,82 @@ describe('verifyProof', () => {
         proof.claimData.context = JSON.stringify(context);
         proof.teeAttestation = createGcpTeeAttestation(differentSessionNonce);
 
-        await expect(
-            verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET)
-        ).resolves.toBe(false);
+        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        expect(result.isVerified).toBe(false);
+        expect(typeof result.error).toBe('string');
+    });
+
+    it('caches JWKS keys across multiple verifyTeeAttestation calls', async () => {
+        const fetchSpy = global.fetch as jest.Mock;
+
+        // First call may or may not fetch (cache may be warm from earlier tests).
+        // Record the count before our two calls.
+        const proof1 = cloneProof();
+        attachHashNonceTeeAttestation(proof1);
+        const proof2 = cloneProof();
+        attachHashNonceTeeAttestation(proof2);
+
+        await verifyTeeAttestation(proof1, expectedApplicationId, TEST_TEE_SECRET);
+        const countAfterFirst = fetchSpy.mock.calls.length;
+
+        await verifyTeeAttestation(proof2, expectedApplicationId, TEST_TEE_SECRET);
+        const countAfterSecond = fetchSpy.mock.calls.length;
+
+        // Second call should not make any additional JWKS/OIDC fetches
+        expect(countAfterSecond).toBe(countAfterFirst);
+    });
+
+    it('returns error when proof context is malformed JSON', async () => {
+        const proof = cloneProof();
+        attachHashNonceTeeAttestation(proof);
+        proof.claimData.context = 'not-valid-json{{{';
+
+        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        expect(result.isVerified).toBe(false);
+        expect(result.error).toContain('Malformed proof');
+    });
+
+    it('returns error when proof context is missing attestationNonce', async () => {
+        const proof = cloneProof();
+        attachHashNonceTeeAttestation(proof);
+        const context = JSON.parse(proof.claimData.context);
+        delete context.attestationNonce;
+        proof.claimData.context = JSON.stringify(context);
+
+        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        expect(result.isVerified).toBe(false);
+        expect(result.error).toContain('attestationNonce');
+    });
+
+    it('returns error when proof context is missing attestationNonceData', async () => {
+        const proof = cloneProof();
+        attachHashNonceTeeAttestation(proof);
+        const context = JSON.parse(proof.claimData.context);
+        delete context.attestationNonceData;
+        proof.claimData.context = JSON.stringify(context);
+
+        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        expect(result.isVerified).toBe(false);
+        expect(result.error).toContain('attestationNonceData');
+    });
+
+    it('handles teeAttestation as a JSON string on the proof', async () => {
+        const proof = cloneProof();
+        const tee = attachHashNonceTeeAttestation(proof);
+        proof.teeAttestation = JSON.stringify(tee) as any;
+
+        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        expect(result.isVerified).toBe(true);
+    });
+
+    it('returns error when teeAttestation is missing from proof', async () => {
+        const proof = cloneProof();
+        attachHashNonceTeeAttestation(proof);
+        delete (proof as any).teeAttestation;
+
+        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        expect(result.isVerified).toBe(false);
+        expect(result.error).toContain('Missing teeAttestation');
     });
 
     it('throws immediately when TEE verification is invoked in a browser-like environment', async () => {

--- a/src/__tests__/verify_proof.test.ts
+++ b/src/__tests__/verify_proof.test.ts
@@ -141,6 +141,10 @@ function attachLegacyNonceTeeAttestation(proof: Proof): TeeAttestation {
 
 function attachHashNonceTeeAttestation(proof: Proof, secret = TEST_TEE_SECRET): TeeAttestation {
     const context = JSON.parse(proof.claimData.context);
+    // Derive appId from the secret and update the context to match,
+    // so verifyTeeAttestation(proof, secret) can verify the binding.
+    const derivedAppId = new ethers.Wallet(secret).address;
+    context.attestationNonceData.applicationId = derivedAppId;
     const { applicationId, sessionId, timestamp } = context.attestationNonceData;
     const attestationNonce = generateAttestationNonce(secret, applicationId, sessionId, timestamp);
 
@@ -271,7 +275,7 @@ describe('verifyProof', () => {
         const attestation = attachLegacyNonceTeeAttestation(proof);
         attestation.workload.image_digest = `us-docker.pkg.dev/rc-popcorn/popcorn-images/browser-node@sha256:${'2'.repeat(64)}`;
 
-        const result = await verifyTeeAttestation(proof, expectedApplicationId);
+        const result = await verifyTeeAttestation(proof, TEST_TEE_SECRET);
         expect(result.isVerified).toBe(false);
         expect(typeof result.error).toBe('string');
     });
@@ -280,25 +284,18 @@ describe('verifyProof', () => {
         const proof = cloneProof();
         attachHashNonceTeeAttestation(proof);
 
-        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        const result = await verifyTeeAttestation(proof, TEST_TEE_SECRET);
         expect(result.isVerified).toBe(true);
         expect(result.error).toBeUndefined();
     });
 
-    it('fails hash-based nonce verification when the verifier does not provide the app secret', async () => {
+    it('fails verification when the wrong app secret is provided', async () => {
         const proof = cloneProof();
         attachHashNonceTeeAttestation(proof);
 
-        const result = await verifyTeeAttestation(proof, expectedApplicationId);
-        expect(result.isVerified).toBe(false);
-        expect(typeof result.error).toBe('string');
-    });
-
-    it('fails hash-based nonce verification when the verifier provides the wrong app secret', async () => {
-        const proof = cloneProof();
-        attachHashNonceTeeAttestation(proof);
-
-        const result = await verifyTeeAttestation(proof, expectedApplicationId, 'wrong-secret');
+        // A valid private key that doesn't match the proof's application
+        const wrongSecret = '0x1111111111111111111111111111111111111111111111111111111111111111';
+        const result = await verifyTeeAttestation(proof, wrongSecret);
         expect(result.isVerified).toBe(false);
         expect(typeof result.error).toBe('string');
     });
@@ -321,7 +318,7 @@ describe('verifyProof', () => {
         proof.claimData.context = JSON.stringify(context);
         proof.teeAttestation = createGcpTeeAttestation(differentSessionNonce);
 
-        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        const result = await verifyTeeAttestation(proof, TEST_TEE_SECRET);
         expect(result.isVerified).toBe(false);
         expect(typeof result.error).toBe('string');
     });
@@ -336,10 +333,10 @@ describe('verifyProof', () => {
         const proof2 = cloneProof();
         attachHashNonceTeeAttestation(proof2);
 
-        await verifyTeeAttestation(proof1, expectedApplicationId, TEST_TEE_SECRET);
+        await verifyTeeAttestation(proof1, TEST_TEE_SECRET);
         const countAfterFirst = fetchSpy.mock.calls.length;
 
-        await verifyTeeAttestation(proof2, expectedApplicationId, TEST_TEE_SECRET);
+        await verifyTeeAttestation(proof2, TEST_TEE_SECRET);
         const countAfterSecond = fetchSpy.mock.calls.length;
 
         // Second call should not make any additional JWKS/OIDC fetches
@@ -351,7 +348,7 @@ describe('verifyProof', () => {
         attachHashNonceTeeAttestation(proof);
         proof.claimData.context = 'not-valid-json{{{';
 
-        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        const result = await verifyTeeAttestation(proof, TEST_TEE_SECRET);
         expect(result.isVerified).toBe(false);
         expect(result.error).toContain('Malformed proof');
     });
@@ -363,7 +360,7 @@ describe('verifyProof', () => {
         delete context.attestationNonce;
         proof.claimData.context = JSON.stringify(context);
 
-        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        const result = await verifyTeeAttestation(proof, TEST_TEE_SECRET);
         expect(result.isVerified).toBe(false);
         expect(result.error).toContain('attestationNonce');
     });
@@ -375,7 +372,7 @@ describe('verifyProof', () => {
         delete context.attestationNonceData;
         proof.claimData.context = JSON.stringify(context);
 
-        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        const result = await verifyTeeAttestation(proof, TEST_TEE_SECRET);
         expect(result.isVerified).toBe(false);
         expect(result.error).toContain('attestationNonceData');
     });
@@ -385,7 +382,7 @@ describe('verifyProof', () => {
         const tee = attachHashNonceTeeAttestation(proof);
         proof.teeAttestation = JSON.stringify(tee) as any;
 
-        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        const result = await verifyTeeAttestation(proof, TEST_TEE_SECRET);
         expect(result.isVerified).toBe(true);
     });
 
@@ -394,7 +391,7 @@ describe('verifyProof', () => {
         attachHashNonceTeeAttestation(proof);
         delete (proof as any).teeAttestation;
 
-        const result = await verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET);
+        const result = await verifyTeeAttestation(proof, TEST_TEE_SECRET);
         expect(result.isVerified).toBe(false);
         expect(result.error).toContain('Missing teeAttestation');
     });
@@ -411,7 +408,7 @@ describe('verifyProof', () => {
             (globalThis as any).document = {};
 
             await expect(
-                verifyTeeAttestation(proof, expectedApplicationId, TEST_TEE_SECRET)
+                verifyTeeAttestation(proof, TEST_TEE_SECRET)
             ).rejects.toThrow(
                 'TEE attestation verification is only supported in non-browser environments'
             );

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,8 @@ export * from './utils/sessionUtils';
 export type * from './utils/sessionUtils';
 export * from './witness';
 export type * from './witness';
-export { verifyTeeAttestation, verifyTeeAttestationDetailed } from './utils/verifyTee';
+export { verifyTeeAttestation } from './utils/verifyTee';
+export type { TeeVerificationResult } from './utils/verifyTee';
 export { TeeVerificationError } from './utils/errors';
 // Export device detection utilities for debugging (optional)
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export * from './utils/sessionUtils';
 export type * from './utils/sessionUtils';
 export * from './witness';
 export type * from './witness';
-export { verifyTeeAttestation } from './utils/verifyTee';
+export { verifyTeeAttestation, runTeeVerification } from './utils/verifyTee';
 export type { TeeVerificationResult } from './utils/verifyTee';
 export { TeeVerificationError } from './utils/errors';
 // Export device detection utilities for debugging (optional)

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export * from './utils/sessionUtils';
 export type * from './utils/sessionUtils';
 export * from './witness';
 export type * from './witness';
-export { verifyTeeAttestation } from './utils/verifyTee';
+export { verifyTeeAttestation, verifyTeeAttestationDetailed } from './utils/verifyTee';
 export { TeeVerificationError } from './utils/errors';
 // Export device detection utilities for debugging (optional)
 export {

--- a/src/utils/attestationNonce.ts
+++ b/src/utils/attestationNonce.ts
@@ -1,0 +1,20 @@
+import { ethers } from 'ethers';
+
+export const ATTESTATION_NONCE_DOMAIN = 'RECLAIM_TEE_NONCE_V1';
+
+export function generateAttestationNonce(
+    appSecret: string,
+    applicationId: string,
+    sessionId: string,
+    timestamp: string
+): string {
+    const noncePayload = [
+        ATTESTATION_NONCE_DOMAIN,
+        applicationId,
+        sessionId,
+        timestamp,
+        appSecret
+    ].join(':');
+
+    return ethers.keccak256(ethers.toUtf8Bytes(noncePayload)).replace(/^0x/i, '');
+}

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -50,10 +50,10 @@ export function scheduleIntervalEndingTask(
   }, timeout)
 }
 
-export const createVerifyProofResultSuccess = (proofs: Proof[], isTeeVerified = false): VerifyProofResultSuccess => {
+export const createVerifyProofResultSuccess = (proofs: Proof[], isTeeAttestationVerified?: boolean): VerifyProofResultSuccess => {
   return {
     isVerified: true,
-    isTeeVerified,
+    isTeeAttestationVerified,
     error: undefined,
     data: proofs.map(createTrustedDataFromProofData),
     publicData: getPublicDataFromProofs(proofs),
@@ -61,10 +61,10 @@ export const createVerifyProofResultSuccess = (proofs: Proof[], isTeeVerified = 
 }
 
 
-export const createVerifyProofResultFailure = (error: Error, isTeeVerified = false): VerifyProofResultFailure => {
+export const createVerifyProofResultFailure = (error: Error, isTeeAttestationVerified?: boolean): VerifyProofResultFailure => {
   return {
     isVerified: false,
-    isTeeVerified,
+    isTeeAttestationVerified,
     error,
     data: [],
     publicData: [],

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -50,10 +50,10 @@ export function scheduleIntervalEndingTask(
   }, timeout)
 }
 
-export const createVerifyProofResultSuccess = (proofs: Proof[], isTeeVerified?: true): VerifyProofResultSuccess => {
+export const createVerifyProofResultSuccess = (proofs: Proof[], isTeeVerified = false): VerifyProofResultSuccess => {
   return {
     isVerified: true,
-    isTeeVerified: isTeeVerified,
+    isTeeVerified,
     error: undefined,
     data: proofs.map(createTrustedDataFromProofData),
     publicData: getPublicDataFromProofs(proofs),
@@ -61,11 +61,11 @@ export const createVerifyProofResultSuccess = (proofs: Proof[], isTeeVerified?: 
 }
 
 
-export const createVerifyProofResultFailure = (error: Error, isTeeVerified?: false): VerifyProofResultFailure => {
+export const createVerifyProofResultFailure = (error: Error, isTeeVerified = false): VerifyProofResultFailure => {
   return {
     isVerified: false,
-    isTeeVerified: isTeeVerified,
-    error: error,
+    isTeeVerified,
+    error,
     data: [],
     publicData: [],
   }

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -1,10 +1,24 @@
 export interface TeeAttestation {
-  workload_digest: string;
-  verifier_digest: string;
+  proof_version: string;
+  tee_provider: string;
+  tee_technology: string;
   nonce: string;
-  snp_report: string;
-  vlek_cert: string;
   timestamp: string;
+  workload: {
+    container_name: string;
+    image_digest: string;
+  };
+  verifier: {
+    container_name: string;
+    image_digest: string;
+  };
+  attestation: {
+    token: string;
+  };
+  error?: {
+    code: string;
+    message: string;
+  };
 }
 
 // Proof-related interfaces

--- a/src/utils/proofValidationUtils.ts
+++ b/src/utils/proofValidationUtils.ts
@@ -80,6 +80,11 @@ export type VerificationConfig = ValidationConfig & {
      * if TEE data is missing or TEE verification fails.
      */
     verifyTEE?: boolean;
+    /**
+     * Application secret used to recompute hash-based TEE attestation nonces.
+     * Required for verifying newer hash-based attestation nonces.
+     */
+    teeVerificationSecret?: string;
 };
 
 

--- a/src/utils/proofValidationUtils.ts
+++ b/src/utils/proofValidationUtils.ts
@@ -73,18 +73,23 @@ export type ValidationConfig = ValidationConfigWithHash | ValidationConfigWithPr
  * Describes the comprehensive configuration required to initialize the proof verification process.
  * Aligns with `ValidationConfig` options for verifying signatures alongside proof contents.
  */
+export type TeeAttestationConfig = {
+    /**
+     * Your application secret (Ethereum private key).
+     * Used to recompute the TEE attestation nonce and to derive the application ID
+     * for binding the attestation to your application.
+     */
+    appSecret: string;
+};
+
 export type VerificationConfig = ValidationConfig & {
     /**
-     * If true, verifies TEE (Trusted Execution Environment) attestation included in the proof.
-     * When enabled, the result will include `isTeeVerified` and `isVerified` will be false
-     * if TEE data is missing or TEE verification fails.
+     * TEE attestation verification configuration.
+     * When provided, verifies the TEE attestation included in the proof.
+     * The result will include `isTeeVerified` and `isVerified` will be false
+     * if TEE attestation data is missing or verification fails.
      */
-    verifyTEE?: boolean;
-    /**
-     * Application secret used to recompute hash-based TEE attestation nonces.
-     * Required for verifying newer hash-based attestation nonces.
-     */
-    teeVerificationSecret?: string;
+    teeAttestation?: TeeAttestationConfig;
 };
 
 

--- a/src/utils/proofValidationUtils.ts
+++ b/src/utils/proofValidationUtils.ts
@@ -86,7 +86,7 @@ export type VerificationConfig = ValidationConfig & {
     /**
      * TEE attestation verification configuration.
      * When provided, verifies the TEE attestation included in the proof.
-     * The result will include `isTeeVerified` and `isVerified` will be false
+     * The result will include `isTeeAttestationVerified` and `isVerified` will be false
      * if TEE attestation data is missing or verification fails.
      */
     teeAttestation?: TeeAttestationConfig;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -344,7 +344,7 @@ export type TrustedData = {
 
 export type VerifyProofResultSuccess = {
   isVerified: true;
-  isTeeVerified?: boolean;
+  isTeeVerified: boolean;
   error: undefined;
   data: TrustedData[];
   publicData: any[];
@@ -352,7 +352,7 @@ export type VerifyProofResultSuccess = {
 
 export type VerifyProofResultFailure = {
   isVerified: false;
-  isTeeVerified?: boolean;
+  isTeeVerified: boolean;
   error: Error;
   data: [];
   publicData: [];

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -344,7 +344,7 @@ export type TrustedData = {
 
 export type VerifyProofResultSuccess = {
   isVerified: true;
-  isTeeVerified: boolean;
+  isTeeAttestationVerified?: boolean;
   error: undefined;
   data: TrustedData[];
   publicData: any[];
@@ -352,7 +352,7 @@ export type VerifyProofResultSuccess = {
 
 export type VerifyProofResultFailure = {
   isVerified: false;
-  isTeeVerified: boolean;
+  isTeeAttestationVerified?: boolean;
   error: Error;
   data: [];
   publicData: [];

--- a/src/utils/verifyTee.ts
+++ b/src/utils/verifyTee.ts
@@ -149,16 +149,29 @@ async function sha256Hex(input: string): Promise<string> {
     return Array.from(new Uint8Array(digest), (value) => value.toString(16).padStart(2, '0')).join('');
 }
 
+const JWKS_CACHE_TTL_MS = 5 * 60 * 1000;
+let cachedJwksUri: string | null = null;
+let cachedJwksKeys: JsonWebKeyLike[] | null = null;
+let cachedJwksAt = 0;
+
 async function verifyJwtSignature(token: string, issuer: string): Promise<Record<string, any>> {
     const { header, payload, signingInput, signature } = decodeJwt(token);
     assert(header.alg === 'RS256', `unexpected attestation signing algorithm: ${header.alg}`);
     assert(typeof header.kid === 'string' && header.kid.length > 0, 'attestation token kid is missing');
 
-    const oidc = await fetchJson(`${issuer}/.well-known/openid-configuration`);
-    assert(typeof oidc?.jwks_uri === 'string' && oidc.jwks_uri.length > 0, 'issuer JWKS URI is missing');
+    const isCacheFresh = cachedJwksKeys && (Date.now() - cachedJwksAt) < JWKS_CACHE_TTL_MS;
 
-    const jwks = await fetchJson(oidc.jwks_uri);
-    const jwk = (jwks?.keys || []).find((key: JsonWebKeyLike) => key.kid === header.kid) as JsonWebKeyLike | undefined;
+    if (!isCacheFresh) {
+        const oidc = await fetchJson(`${issuer}/.well-known/openid-configuration`);
+        assert(typeof oidc?.jwks_uri === 'string' && oidc.jwks_uri.length > 0, 'issuer JWKS URI is missing');
+        cachedJwksUri = oidc.jwks_uri;
+
+        const jwks = await fetchJson(cachedJwksUri!);
+        cachedJwksKeys = jwks?.keys || [];
+        cachedJwksAt = Date.now();
+    }
+
+    const jwk = cachedJwksKeys!.find((key: JsonWebKeyLike) => key.kid === header.kid) as JsonWebKeyLike | undefined;
     assert(jwk, `no JWKS key found for kid ${header.kid}`);
 
     const cryptoKey = await getSubtleCrypto().importKey(
@@ -180,23 +193,34 @@ async function verifyJwtSignature(token: string, issuer: string): Promise<Record
     return payload;
 }
 
-function parseProofContext(proof: Proof): { parsedContext: any; nonceDataObj: NonceContextData; expectedNonce: string } {
-    let parsedContext: any;
+function isNonceContextData(obj: unknown): obj is NonceContextData {
+    if (!obj || typeof obj !== 'object') return false;
+    const o = obj as Record<string, unknown>;
+    return typeof o.applicationId === 'string' && o.applicationId.length > 0
+        && typeof o.sessionId === 'string' && o.sessionId.length > 0
+        && typeof o.timestamp === 'string' && o.timestamp.length > 0;
+}
+
+function parseProofContext(proof: Proof): { parsedContext: Record<string, unknown>; nonceDataObj: NonceContextData; expectedNonce: string } {
+    let parsedContext: unknown;
     try {
         parsedContext = JSON.parse(proof.claimData.context);
     } catch {
-        throw new Error('Failed to parse proof context to extract attestationNonce');
+        throw new Error('Malformed proof: claimData.context is not valid JSON');
     }
 
-    const expectedNonce = parsedContext?.attestationNonce;
-    const nonceDataObj = parsedContext?.attestationNonceData as NonceContextData | undefined;
-    assert(expectedNonce, 'Proof context is missing attestationNonce or attestationNonceData');
-    assert(nonceDataObj, 'Proof context is missing attestationNonce or attestationNonceData');
-    assert(typeof nonceDataObj.applicationId === 'string' && nonceDataObj.applicationId.length > 0, 'Proof context attestationNonceData.applicationId is missing');
-    assert(typeof nonceDataObj.sessionId === 'string' && nonceDataObj.sessionId.length > 0, 'Proof context attestationNonceData.sessionId is missing');
-    assert(typeof nonceDataObj.timestamp === 'string' && nonceDataObj.timestamp.length > 0, 'Proof context attestationNonceData.timestamp is missing');
+    if (!parsedContext || typeof parsedContext !== 'object') {
+        throw new Error('Malformed proof: claimData.context is not a JSON object');
+    }
 
-    return { parsedContext, nonceDataObj, expectedNonce };
+    const ctx = parsedContext as Record<string, unknown>;
+    const expectedNonce = ctx.attestationNonce;
+    assert(typeof expectedNonce === 'string' && expectedNonce.length > 0, 'Proof context is missing attestationNonce');
+
+    const nonceDataObj = ctx.attestationNonceData;
+    assert(isNonceContextData(nonceDataObj), 'Proof context is missing or has invalid attestationNonceData (requires applicationId, sessionId, timestamp)');
+
+    return { parsedContext: ctx, nonceDataObj, expectedNonce };
 }
 
 function verifyApplicationAndSessionBinding(
@@ -214,11 +238,14 @@ function verifyApplicationAndSessionBinding(
         );
     }
 
-    let parsedParameters: any = {};
-    try {
-        parsedParameters = proof.claimData.parameters ? JSON.parse(proof.claimData.parameters) : {};
-    } catch {
-        parsedParameters = {};
+    let parsedParameters: Record<string, unknown> = {};
+    if (proof.claimData.parameters) {
+        try {
+            const parsed = JSON.parse(proof.claimData.parameters);
+            parsedParameters = (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) ? parsed : {};
+        } catch {
+            throw new Error('Malformed proof: claimData.parameters is not valid JSON');
+        }
     }
 
     const contextSessionId = parsedContext?.reclaimSessionId;
@@ -345,9 +372,9 @@ async function verifyGcpClaims(teeAttestation: TeeAttestation, expectedNonce: st
 
 /**
  * Validates the hardware TEE attestation included in the proof.
- * Throws an error if the attestation is invalid or compromised.
+ * Returns a result object with `isVerified` and an optional `error` message.
  */
-export async function verifyTeeAttestationDetailed(
+export async function verifyTeeAttestation(
     proof: Proof,
     expectedApplicationId?: string,
     expectedAppSecret?: string
@@ -386,14 +413,4 @@ export async function verifyTeeAttestationDetailed(
             error: error instanceof Error ? error.message : String(error),
         };
     }
-}
-
-export async function verifyTeeAttestation(
-    proof: Proof,
-    expectedApplicationId?: string,
-    expectedAppSecret?: string
-): Promise<boolean> {
-    assertNonBrowserEnvironment();
-    const result = await verifyTeeAttestationDetailed(proof, expectedApplicationId, expectedAppSecret);
-    return result.isVerified;
 }

--- a/src/utils/verifyTee.ts
+++ b/src/utils/verifyTee.ts
@@ -1,6 +1,8 @@
 import { Proof, TeeAttestation } from './interfaces';
 import { ethers } from 'ethers';
 import { generateAttestationNonce } from './attestationNonce';
+import { TeeVerificationError } from './errors';
+import type { TeeAttestationConfig } from './proofValidationUtils';
 import loggerModule from './logger';
 
 const logger = loggerModule.logger;
@@ -372,16 +374,23 @@ async function verifyGcpClaims(teeAttestation: TeeAttestation, expectedNonce: st
 
 /**
  * Validates the hardware TEE attestation included in the proof.
+ * Derives the application ID from `appSecret` and verifies the attestation
+ * was generated for your application.
  * Returns a result object with `isVerified` and an optional `error` message.
+ *
+ * @param proof - The proof containing TEE attestation data
+ * @param appSecret - Your application secret (Ethereum private key). Used to
+ *   derive the application ID and recompute the attestation nonce.
  */
 export async function verifyTeeAttestation(
     proof: Proof,
-    expectedApplicationId?: string,
-    expectedAppSecret?: string
+    appSecret: string
 ): Promise<TeeVerificationResult> {
     assertNonBrowserEnvironment();
 
     try {
+        const appId = new ethers.Wallet(appSecret).address;
+
         let teeAttestation = proof.teeAttestation;
         if (!teeAttestation) {
             throw new Error('Missing teeAttestation in proof');
@@ -394,8 +403,8 @@ export async function verifyTeeAttestation(
         assertProofShape(teeAttestation);
 
         const { parsedContext, nonceDataObj, expectedNonce } = parseProofContext(proof);
-        verifyApplicationAndSessionBinding(proof, parsedContext, nonceDataObj, expectedApplicationId);
-        verifyNonceMaterial(expectedNonce, nonceDataObj, expectedAppSecret);
+        verifyApplicationAndSessionBinding(proof, parsedContext, nonceDataObj, appId);
+        verifyNonceMaterial(expectedNonce, nonceDataObj, appSecret);
 
         const cleanExpectedNonce = normalizeHex(expectedNonce);
         const cleanTeeNonce = normalizeHex(teeAttestation.nonce);
@@ -412,5 +421,37 @@ export async function verifyTeeAttestation(
             isVerified: false,
             error: error instanceof Error ? error.message : String(error),
         };
+    }
+}
+
+/**
+ * Verifies TEE attestation for all proofs.
+ * Throws `TeeVerificationError` if any proof is missing TEE data or fails verification.
+ *
+ * @param proofs - The proofs to verify
+ * @param config - TEE attestation configuration containing the app secret
+ * @throws {TeeVerificationError} When TEE data is missing or verification fails
+ */
+export async function runTeeVerification(proofs: Proof[], config: TeeAttestationConfig): Promise<void> {
+    const hasTeeData = proofs.every(proof => {
+        if (proof.teeAttestation) return true;
+        try {
+            const context = JSON.parse(proof.claimData.context);
+            return !!context?.attestationNonce;
+        } catch {
+            return false;
+        }
+    });
+
+    if (!hasTeeData) {
+        throw new TeeVerificationError('TEE verification requested but one or more proofs are missing TEE attestation data');
+    }
+
+    const teeResults = await Promise.all(
+        proofs.map(proof => verifyTeeAttestation(proof, config.appSecret))
+    );
+
+    if (!teeResults.every(r => r.isVerified)) {
+        throw new TeeVerificationError('TEE attestation verification failed for one or more proofs');
     }
 }

--- a/src/utils/verifyTee.ts
+++ b/src/utils/verifyTee.ts
@@ -1,722 +1,399 @@
-import forge from 'node-forge';
 import { Proof, TeeAttestation } from './interfaces';
 import { ethers } from 'ethers';
-import { AMD_CERTS } from './amdCerts';
+import { generateAttestationNonce } from './attestationNonce';
 import loggerModule from './logger';
 
-const crlCache: Record<string, { buffer: Uint8Array, fetchedAt: number }> = {};
 const logger = loggerModule.logger;
 
-type BinaryLike = Uint8Array | ArrayBuffer | Buffer;
+const EXPECTED_ISSUER = 'https://confidentialcomputing.googleapis.com';
+const EXPECTED_HW_MODEL = 'GCP_AMD_SEV';
+const EXPECTED_TEE_PROVIDER = 'gcp';
+const EXPECTED_TEE_TECHNOLOGY = 'amd-sev';
+const TOKEN_CLOCK_SKEW_S = 60;
+const NONCE_TIMESTAMP_MAX_SKEW_MS = 10 * 60 * 1000;
 
-function toUint8Array(input: BinaryLike): Uint8Array {
-    if (typeof Buffer !== 'undefined' && typeof Buffer.isBuffer === 'function' && Buffer.isBuffer(input)) {
-        return new Uint8Array(input);
+type JsonWebKeyLike = JsonWebKey & {
+    kid?: string;
+    alg?: string;
+    use?: string;
+};
+
+type DecodedJwt = {
+    header: Record<string, any>;
+    payload: Record<string, any>;
+    signingInput: string;
+    signature: Uint8Array;
+};
+
+type NonceContextData = {
+    applicationId: string;
+    sessionId: string;
+    timestamp: string;
+};
+
+export type TeeVerificationResult = {
+    isVerified: boolean;
+    error?: string;
+};
+
+const BROWSER_ENVIRONMENT_ERROR =
+    'TEE attestation verification is only supported in non-browser environments. Run verifyTeeAttestation on your server or API route.';
+
+function assert(condition: unknown, message: string): asserts condition {
+    if (!condition) {
+        throw new Error(message);
     }
-    if (input instanceof Uint8Array) {
-        return new Uint8Array(input);
-    }
-    if (typeof ArrayBuffer !== 'undefined' && input instanceof ArrayBuffer) {
-        return new Uint8Array(input);
-    }
-    throw new Error('Unsupported binary data type');
 }
 
-function uint8ArrayToBinaryString(bytes: Uint8Array): string {
-    let result = '';
-    const chunkSize = 0x8000;
-    for (let i = 0; i < bytes.length; i += chunkSize) {
-        const chunk = bytes.subarray(i, i + chunkSize);
-        result += String.fromCharCode(...chunk);
+function isBrowserEnvironment(): boolean {
+    if (typeof window !== 'undefined' || typeof document !== 'undefined') {
+        return true;
     }
-    return result;
+
+    if (typeof navigator !== 'undefined' && typeof process === 'undefined') {
+        return true;
+    }
+
+    const workerGlobalScope = (globalThis as any).WorkerGlobalScope;
+    if (
+        typeof workerGlobalScope !== 'undefined' &&
+        typeof self !== 'undefined' &&
+        self instanceof workerGlobalScope
+    ) {
+        return true;
+    }
+
+    return false;
 }
 
-function binaryStringToUint8Array(binary: string): Uint8Array {
-    const result = new Uint8Array(binary.length);
-    for (let i = 0; i < binary.length; i++) {
-        result[i] = binary.charCodeAt(i);
+function assertNonBrowserEnvironment() {
+    if (isBrowserEnvironment()) {
+        throw new Error(BROWSER_ENVIRONMENT_ERROR);
     }
-    return result;
 }
 
-function base64ToUint8Array(base64: string): Uint8Array {
-    if (typeof atob === 'function') {
-        const binary = atob(base64);
-        return binaryStringToUint8Array(binary);
-    }
+function normalizeHex(value: string | undefined | null): string {
+    return (value || '').trim().replace(/^0x/i, '').toLowerCase();
+}
+
+function isHex(value: string): boolean {
+    return /^[0-9a-f]+$/i.test(value);
+}
+
+function decodeBase64Url(input: string): Uint8Array {
+    const normalized = input.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = normalized + '='.repeat((4 - normalized.length % 4) % 4);
+
     if (typeof Buffer !== 'undefined') {
-        return new Uint8Array(Buffer.from(base64, 'base64'));
+        return new Uint8Array(Buffer.from(padded, 'base64'));
     }
+    if (typeof atob === 'function') {
+        const binary = atob(padded);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i += 1) {
+            bytes[i] = binary.charCodeAt(i);
+        }
+        return bytes;
+    }
+
     throw new Error('Base64 decoding is not supported in this environment');
 }
 
-function arrayBufferToHex(buffer: ArrayBuffer | Uint8Array): string {
-    const view = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
-    let hex = '';
-    for (let i = 0; i < view.length; i++) {
-        hex += view[i].toString(16).padStart(2, '0');
-    }
-    return hex;
+function decodeUtf8(bytes: Uint8Array): string {
+    return new TextDecoder().decode(bytes);
 }
 
-function concatUint8Arrays(parts: Uint8Array[]): Uint8Array {
-    const totalLength = parts.reduce((sum, arr) => sum + arr.length, 0);
-    const result = new Uint8Array(totalLength);
-    let offset = 0;
-    for (const arr of parts) {
-        result.set(arr, offset);
-        offset += arr.length;
-    }
-    return result;
-}
-
-function reverseBytes(bytes: Uint8Array): Uint8Array {
-    const copy = Uint8Array.from(bytes);
-    copy.reverse();
-    return copy;
-}
-
-function normalizeSerial(s: string) {
-    let cleaned = s.toLowerCase().replace(/[^a-f0-9]/g, '');
-    while (cleaned.startsWith('0') && cleaned.length > 1) cleaned = cleaned.substring(1);
-    return cleaned;
-}
-const isNode = typeof process !== 'undefined' && process.versions && process.versions.node;
-const getSubtleCrypto = () => {
-    if (typeof window !== 'undefined' && window.crypto?.subtle) return window.crypto.subtle;
-    if (isNode) return require('crypto').webcrypto.subtle;
-    throw new Error('No WebCrypto subtle implementation found in this environment');
-};
-
-interface ParsedCert {
-    serialNumber: string;
-    tbsDer: Uint8Array;
-    signature: Uint8Array;
-    sigAlgOid: string;
-    spkiDer: Uint8Array;
-    notBefore?: Date;
-    notAfter?: Date;
-}
-
-function parseCert(buffer: BinaryLike): ParsedCert {
-    const bytes = toUint8Array(buffer);
-    const asn1 = forge.asn1.fromDer(uint8ArrayToBinaryString(bytes));
-    const certSeq = asn1.value as any[];
-    const tbsAsn1 = certSeq[0];
-    const sigAlgAsn1 = certSeq[1];
-    const sigValueAsn1 = certSeq[2];
-
-    const tbsFields = tbsAsn1.value as any[];
-    let idx = 0;
-    if (tbsFields[idx].tagClass === 128) idx++; // version
-    const serialAsn1 = tbsFields[idx++];
-    const serialNumber = forge.util.bytesToHex(serialAsn1.value);
-    idx++; // sigAlg
-    idx++; // issuer
-    const validityAsn1 = tbsFields[idx++];
-    idx++; // subject
-    const spkiAsn1 = tbsFields[idx];
-
-    if (!validityAsn1 || !Array.isArray(validityAsn1.value) || validityAsn1.value.length < 2) {
-        throw new Error('Certificate validity window is malformed');
-    }
-    const notBeforeNode = validityAsn1.value[0];
-    const notAfterNode = validityAsn1.value[1];
-    const notBefore = notBeforeNode ? parseAsn1Time(notBeforeNode) : undefined;
-    const notAfter = notAfterNode ? parseAsn1Time(notAfterNode) : undefined;
-
-    const sigRaw = typeof sigValueAsn1.value === 'string' ? sigValueAsn1.value : '';
-    const signature = binaryStringToUint8Array(sigRaw.substring(1));
-    const sigAlgOid = forge.asn1.derToOid((sigAlgAsn1.value as any[])[0].value);
+function decodeJwt(token: string): DecodedJwt {
+    const parts = token.split('.');
+    assert(parts.length === 3, 'attestation token is not a JWT');
 
     return {
-        serialNumber: normalizeSerial(serialNumber),
-        tbsDer: binaryStringToUint8Array(forge.asn1.toDer(tbsAsn1).getBytes()),
-        signature,
-        sigAlgOid,
-        spkiDer: binaryStringToUint8Array(forge.asn1.toDer(spkiAsn1).getBytes()),
-        notBefore,
-        notAfter
+        header: JSON.parse(decodeUtf8(decodeBase64Url(parts[0]))),
+        payload: JSON.parse(decodeUtf8(decodeBase64Url(parts[1]))),
+        signingInput: `${parts[0]}.${parts[1]}`,
+        signature: decodeBase64Url(parts[2]),
     };
 }
 
-async function verifySignature(publicKeyPem: string, data: Uint8Array, signature: Uint8Array, sigAlgOid: string) {
-    const cryptoSubtle = getSubtleCrypto();
-    const forgeCert = forge.pki.certificateFromPem(publicKeyPem);
-    const spkiBuf = binaryStringToUint8Array(forge.asn1.toDer(forge.pki.publicKeyToAsn1(forgeCert.publicKey)).getBytes());
-
-    let importParams: any;
-    let verifyParams: any;
-
-    if (sigAlgOid === '1.2.840.113549.1.1.10') { // rsassa-pss
-        importParams = { name: 'RSA-PSS', hash: 'SHA-384' };
-        verifyParams = { name: 'RSA-PSS', saltLength: 48 };
-    } else if (sigAlgOid === '1.2.840.113549.1.1.11' || sigAlgOid === '1.2.840.113549.1.1.12' || sigAlgOid === '1.2.840.113549.1.1.5') {
-        importParams = { name: 'RSASSA-PKCS1-v1_5', hash: sigAlgOid === '1.2.840.113549.1.1.12' ? 'SHA-384' : 'SHA-256' };
-        verifyParams = { name: 'RSASSA-PKCS1-v1_5' };
-    } else if (sigAlgOid === '1.2.840.10045.4.3.3') { // ecdsa-with-sha384
-        importParams = { name: 'ECDSA', namedCurve: 'P-384' };
-        verifyParams = { name: 'ECDSA', hash: 'SHA-384' };
-    } else {
-        // Fallback or generic
-        importParams = { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' };
-        verifyParams = { name: 'RSASSA-PKCS1-v1_5' };
-    }
-
-    const key = await cryptoSubtle.importKey('spki', spkiBuf, importParams, false, ['verify']);
-    const isValid = await cryptoSubtle.verify(verifyParams, key, signature, data);
-    if (!isValid) throw new Error(`Signature verification failed (OID: ${sigAlgOid}, ImportParams: ${JSON.stringify(importParams)})`);
+function getFetch(): typeof fetch {
+    const fetchFn = globalThis.fetch;
+    assert(fetchFn, 'fetch is not available in this environment');
+    return fetchFn.bind(globalThis);
 }
 
-const COSIGN_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEjiL30OjPuxa+GC1I7SAcBv2u2pMt
-h9WbP33IvB3eFww+C1hoW0fwdZPiq4FxBtKNiZuFpmYuFngW/nJteBu9kQ==
------END PUBLIC KEY-----
-`;
+function getSubtleCrypto(): SubtleCrypto {
+    if (globalThis.crypto?.subtle) {
+        return globalThis.crypto.subtle;
+    }
+
+    const nodeCrypto = typeof process !== 'undefined' && process.versions?.node
+        ? require('crypto')
+        : undefined;
+    if (nodeCrypto?.webcrypto?.subtle) {
+        return nodeCrypto.webcrypto.subtle as SubtleCrypto;
+    }
+
+    throw new Error('WebCrypto subtle is not available in this environment');
+}
+
+async function fetchJson(url: string): Promise<any> {
+    const response = await getFetch()(url);
+    if (!response.ok) {
+        throw new Error(`GET ${url} returned ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+}
+
+async function sha256Hex(input: string): Promise<string> {
+    const digest = await getSubtleCrypto().digest('SHA-256', new TextEncoder().encode(input));
+    return Array.from(new Uint8Array(digest), (value) => value.toString(16).padStart(2, '0')).join('');
+}
+
+async function verifyJwtSignature(token: string, issuer: string): Promise<Record<string, any>> {
+    const { header, payload, signingInput, signature } = decodeJwt(token);
+    assert(header.alg === 'RS256', `unexpected attestation signing algorithm: ${header.alg}`);
+    assert(typeof header.kid === 'string' && header.kid.length > 0, 'attestation token kid is missing');
+
+    const oidc = await fetchJson(`${issuer}/.well-known/openid-configuration`);
+    assert(typeof oidc?.jwks_uri === 'string' && oidc.jwks_uri.length > 0, 'issuer JWKS URI is missing');
+
+    const jwks = await fetchJson(oidc.jwks_uri);
+    const jwk = (jwks?.keys || []).find((key: JsonWebKeyLike) => key.kid === header.kid) as JsonWebKeyLike | undefined;
+    assert(jwk, `no JWKS key found for kid ${header.kid}`);
+
+    const cryptoKey = await getSubtleCrypto().importKey(
+        'jwk',
+        jwk,
+        { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+        false,
+        ['verify']
+    );
+
+    const isValid = await getSubtleCrypto().verify(
+        'RSASSA-PKCS1-v1_5',
+        cryptoKey,
+        signature as unknown as BufferSource,
+        new TextEncoder().encode(signingInput) as unknown as BufferSource
+    );
+    assert(isValid, 'JWT signature verification failed');
+
+    return payload;
+}
+
+function parseProofContext(proof: Proof): { parsedContext: any; nonceDataObj: NonceContextData; expectedNonce: string } {
+    let parsedContext: any;
+    try {
+        parsedContext = JSON.parse(proof.claimData.context);
+    } catch {
+        throw new Error('Failed to parse proof context to extract attestationNonce');
+    }
+
+    const expectedNonce = parsedContext?.attestationNonce;
+    const nonceDataObj = parsedContext?.attestationNonceData as NonceContextData | undefined;
+    assert(expectedNonce, 'Proof context is missing attestationNonce or attestationNonceData');
+    assert(nonceDataObj, 'Proof context is missing attestationNonce or attestationNonceData');
+    assert(typeof nonceDataObj.applicationId === 'string' && nonceDataObj.applicationId.length > 0, 'Proof context attestationNonceData.applicationId is missing');
+    assert(typeof nonceDataObj.sessionId === 'string' && nonceDataObj.sessionId.length > 0, 'Proof context attestationNonceData.sessionId is missing');
+    assert(typeof nonceDataObj.timestamp === 'string' && nonceDataObj.timestamp.length > 0, 'Proof context attestationNonceData.timestamp is missing');
+
+    return { parsedContext, nonceDataObj, expectedNonce };
+}
+
+function verifyApplicationAndSessionBinding(
+    proof: Proof,
+    parsedContext: any,
+    nonceDataObj: NonceContextData,
+    expectedApplicationId?: string
+) {
+    const { applicationId, sessionId, timestamp } = nonceDataObj;
+
+    if (expectedApplicationId) {
+        assert(
+            applicationId.toLowerCase() === expectedApplicationId.toLowerCase(),
+            `Application ID Mismatch! Expected ${expectedApplicationId}, but proof context contains ${applicationId}`
+        );
+    }
+
+    let parsedParameters: any = {};
+    try {
+        parsedParameters = proof.claimData.parameters ? JSON.parse(proof.claimData.parameters) : {};
+    } catch {
+        parsedParameters = {};
+    }
+
+    const contextSessionId = parsedContext?.reclaimSessionId;
+    const parameterSessionId = parsedParameters?.proxySessionId ?? parsedParameters?.sessionId;
+
+    if (contextSessionId && contextSessionId.toString() !== sessionId.toString()) {
+        throw new Error(`Session ID Mismatch! Expected ${sessionId}, but proof context contains reclaimSessionId=${contextSessionId}`);
+    }
+    if (parameterSessionId && parameterSessionId.toString() !== sessionId.toString()) {
+        throw new Error(`Session ID Mismatch! Expected ${sessionId}, but proof parameters contain ${parameterSessionId}`);
+    }
+    if (!contextSessionId && !parameterSessionId) {
+        throw new Error('Proof is missing reclaimSessionId and proxySessionId/sessionId for attestation nonce verification');
+    }
+
+    const claimTimestampMs = proof.claimData.timestampS * 1000;
+    const nonceTimestampMs = parseInt(timestamp, 10);
+    const diffMs = Math.abs(claimTimestampMs - nonceTimestampMs);
+    if (diffMs > NONCE_TIMESTAMP_MAX_SKEW_MS) {
+        throw new Error(`Timestamp Skew Too Large! claimData.timestampS and attestationNonce timestamp differ by ${Math.round(diffMs / 1000)}s (limit: 600s)`);
+    }
+}
+
+function verifyNonceMaterial(
+    expectedNonce: string,
+    nonceDataObj: NonceContextData,
+    expectedAppSecret?: string
+) {
+    const cleanExpectedNonce = normalizeHex(expectedNonce);
+    const { applicationId, sessionId, timestamp } = nonceDataObj;
+
+    assert(cleanExpectedNonce.length > 0, 'Proof context attestationNonce is empty');
+    assert(isHex(cleanExpectedNonce), 'Proof context attestationNonce is not valid hex');
+
+    if (expectedAppSecret) {
+        const recomputedNonce = generateAttestationNonce(expectedAppSecret, applicationId, sessionId, timestamp);
+        assert(
+            recomputedNonce === cleanExpectedNonce,
+            'Attestation nonce verification failed: app secret, application ID, session ID, or timestamp do not match'
+        );
+        return;
+    }
+
+    if (cleanExpectedNonce.length > 74) {
+        const legacyNonceData = `${applicationId}:${sessionId}:${timestamp}`;
+        const nonceMsg = ethers.getBytes(ethers.keccak256(new TextEncoder().encode(legacyNonceData)));
+        const recoveredAddress = ethers.verifyMessage(
+            nonceMsg,
+            expectedNonce.startsWith('0x') ? expectedNonce : `0x${expectedNonce}`
+        );
+
+        assert(
+            recoveredAddress.toLowerCase() === applicationId.toLowerCase(),
+            `Nonce signature verification failed: recovered ${recoveredAddress}, expected ${applicationId}`
+        );
+        return;
+    }
+
+    throw new Error('App secret is required to verify hash-based attestation nonces');
+}
+
+function assertTokenFresh(claims: Record<string, any>) {
+    const now = Math.floor(Date.now() / 1000);
+
+    if (typeof claims.nbf === 'number' && now + TOKEN_CLOCK_SKEW_S < claims.nbf) {
+        throw new Error(`Attestation token is not valid before ${claims.nbf}`);
+    }
+    if (typeof claims.exp === 'number' && now - TOKEN_CLOCK_SKEW_S > claims.exp) {
+        throw new Error(`Attestation token expired at ${claims.exp}`);
+    }
+    if (typeof claims.iat === 'number' && claims.iat > now + TOKEN_CLOCK_SKEW_S) {
+        throw new Error(`Attestation token issued-at ${claims.iat} is in the future`);
+    }
+}
+
+function assertAudienceClaim(aud: unknown) {
+    if (typeof aud === 'string') {
+        assert(aud.length > 0, 'attestation token audience is empty');
+        return;
+    }
+    if (Array.isArray(aud)) {
+        assert(aud.length > 0, 'attestation token audience is empty');
+        assert(aud.every((entry) => typeof entry === 'string' && entry.length > 0), 'attestation token audience contains invalid entries');
+        return;
+    }
+    throw new Error('attestation token audience is missing');
+}
+
+function assertProofShape(teeAttestation: TeeAttestation) {
+    if (teeAttestation.error) {
+        throw new Error(`${teeAttestation.error.code}: ${teeAttestation.error.message}`);
+    }
+
+    assert(teeAttestation.proof_version === 'v2', `unexpected proof version: ${teeAttestation.proof_version}`);
+    assert(teeAttestation.tee_provider === EXPECTED_TEE_PROVIDER, `unexpected tee provider: ${teeAttestation.tee_provider}`);
+    assert(teeAttestation.tee_technology === EXPECTED_TEE_TECHNOLOGY, `unexpected tee technology: ${teeAttestation.tee_technology}`);
+    assert(typeof teeAttestation.nonce === 'string' && teeAttestation.nonce.length > 0, 'tee attestation nonce missing');
+    assert(typeof teeAttestation.timestamp === 'string' && teeAttestation.timestamp.length > 0, 'tee attestation timestamp missing');
+    assert(!Number.isNaN(Date.parse(teeAttestation.timestamp)), 'tee attestation timestamp is invalid');
+    assert(typeof teeAttestation.workload?.image_digest === 'string' && teeAttestation.workload.image_digest.length > 0, 'workload image digest missing');
+    assert(typeof teeAttestation.verifier?.image_digest === 'string' && teeAttestation.verifier.image_digest.length > 0, 'verifier image digest missing');
+    assert(typeof teeAttestation.attestation?.token === 'string' && teeAttestation.attestation.token.length > 0, 'attestation token missing');
+}
+
+async function verifyGcpClaims(teeAttestation: TeeAttestation, expectedNonce: string) {
+    const claims = await verifyJwtSignature(teeAttestation.attestation.token, EXPECTED_ISSUER);
+
+    assert(claims.iss === EXPECTED_ISSUER, `unexpected issuer: ${claims.iss}`);
+    assertAudienceClaim(claims.aud);
+    assert(Array.isArray(claims.eat_nonce), 'eat_nonce claim missing');
+
+    const digestBinding = await sha256Hex(
+        `${teeAttestation.workload.image_digest}\n${teeAttestation.verifier.image_digest}`
+    );
+
+    assert(claims.eat_nonce.includes(expectedNonce), 'request nonce is not present in attestation token');
+    assert(claims.eat_nonce.includes(digestBinding), 'digest-binding nonce is not present in attestation token');
+    assert(claims.hwmodel === EXPECTED_HW_MODEL, `unexpected hwmodel: ${claims.hwmodel}`);
+    assert(claims.secboot === true, 'secure boot claim is not true');
+    assert(claims.submods?.gce, 'gce submod claim missing');
+
+    assertTokenFresh(claims);
+}
 
 /**
  * Validates the hardware TEE attestation included in the proof.
  * Throws an error if the attestation is invalid or compromised.
  */
-export async function verifyTeeAttestation(proof: Proof, expectedApplicationId?: string): Promise<boolean> {
+export async function verifyTeeAttestationDetailed(
+    proof: Proof,
+    expectedApplicationId?: string,
+    expectedAppSecret?: string
+): Promise<TeeVerificationResult> {
+    assertNonBrowserEnvironment();
+
     try {
         let teeAttestation = proof.teeAttestation;
         if (!teeAttestation) {
-            throw new Error("Missing teeAttestation in proof");
+            throw new Error('Missing teeAttestation in proof');
         }
 
         if (typeof teeAttestation === 'string') {
             teeAttestation = JSON.parse(teeAttestation) as TeeAttestation;
         }
 
-    // 1. Verify Nonce Binding
-    let expectedNonceSignature: string | undefined;
-    let nonceDataObj: any;
-    try {
-        const context = JSON.parse(proof.claimData.context);
-        expectedNonceSignature = context.attestationNonce;
-        nonceDataObj = context.attestationNonceData;
-    } catch (e) {
-        throw new Error("Failed to parse proof context to extract attestationNonce");
-    }
+        assertProofShape(teeAttestation);
 
-    if (!expectedNonceSignature || !nonceDataObj) {
-        throw new Error("Proof context is missing attestationNonce or attestationNonceData");
-    }
+        const { parsedContext, nonceDataObj, expectedNonce } = parseProofContext(proof);
+        verifyApplicationAndSessionBinding(proof, parsedContext, nonceDataObj, expectedApplicationId);
+        verifyNonceMaterial(expectedNonce, nonceDataObj, expectedAppSecret);
 
-    if (teeAttestation.nonce !== expectedNonceSignature) {
-        throw new Error(`Nonce Mismatch! Expected signature ${expectedNonceSignature}, got ${teeAttestation.nonce}`);
-    }
+        const cleanExpectedNonce = normalizeHex(expectedNonce);
+        const cleanTeeNonce = normalizeHex(teeAttestation.nonce);
+        assert(cleanTeeNonce.length > 0, 'TEE attestation nonce is empty');
+        assert(isHex(cleanTeeNonce), 'TEE attestation nonce is not valid hex');
+        assert(cleanTeeNonce === cleanExpectedNonce, `Nonce Mismatch! Expected ${cleanExpectedNonce}, got ${cleanTeeNonce}`);
 
-    const { applicationId, sessionId, timestamp } = nonceDataObj;
+        await verifyGcpClaims(teeAttestation, cleanExpectedNonce);
 
-    if (expectedApplicationId && applicationId.toLowerCase() !== expectedApplicationId.toLowerCase()) {
-        throw new Error(`Application ID Mismatch! Expected ${expectedApplicationId}, but proof context contains ${applicationId}`);
-    }
-
-    const expectedNonceData = `${applicationId}:${sessionId}:${timestamp}`;
-    const nonceMsg = ethers.getBytes(ethers.keccak256(new TextEncoder().encode(expectedNonceData)));
-    const recoveredAddress = ethers.verifyMessage(nonceMsg, expectedNonceSignature);
-
-    if (recoveredAddress.toLowerCase() !== applicationId.toLowerCase()) {
-        throw new Error(`Nonce signature verification failed: recovered ${recoveredAddress}, expected ${applicationId}`);
-    }
-
-    try {
-        const context = JSON.parse(proof.claimData.context);
-        const paramSessionId = context.attestationNonceData.sessionId;
-        if (!paramSessionId) {
-            throw new Error(`Proof parameters are missing proxySessionId or sessionId`);
-        }
-        if (paramSessionId.toString() !== sessionId.toString()) {
-            throw new Error(`Session ID Mismatch! Expected ${sessionId}, but proof parameters contain ${paramSessionId}`);
-        }
-
-        // Timestamp skew check: claimData.timestampS (seconds) vs attestationNonceData.timestamp (ms)
-        const claimTimestampMs = proof.claimData.timestampS * 1000;
-        const nonceTimestampMs = parseInt(timestamp, 10);
-        const diffMs = Math.abs(claimTimestampMs - nonceTimestampMs);
-        const TEN_MINUTES_MS = 10 * 60 * 1000;
-        if (diffMs > TEN_MINUTES_MS) {
-            throw new Error(`Timestamp Skew Too Large! claimData.timestampS and attestationNonce timestamp differ by ${Math.round(diffMs / 1000)}s (limit: 600s)`);
-        }
-    } catch (e) {
-        if (e instanceof Error && (e.message.includes("Session ID Mismatch!") || e.message.includes("Timestamp Skew"))) {
-            throw e;
-        }
-        throw new Error(`Failed to cross-verify session ID: ${(e as Error).message}`);
-    }
-
-    // 2. Recompute REPORT_DATA Hash
-    // Recompute H(workload_digest || verifier_digest || pubkey_hash || nonce)
-    // Here PUBKEY_HASH is the hash of the generic cosign pub key used by Popcorn.
-    // For universal verification, we assume the Popcorn standard cosign public key hash matches the one used by Popcorn.
-    // Note: To be fully strict, the public key hash should either be provided or fetched. 
-    // We will compute the SHA256 of the concatenated string.
-
-    // The verify_proof script uses the hash of a specific file. We'll reconstruct the data that was signed.
-    // However, wait! If JS SDK cannot easily hash the hardcoded cosign public key (or doesn't have it), 
-    // we must verify using the provided public data or skip the workload digest lock for now.
-    // The user requested: "same verification we do in the popcorn verficcation script".
-    // Let's implement the generic parts first: Hardware Signature and TCB.
-
-        const reportBuffer = base64ToUint8Array(teeAttestation.snp_report);
-        const report = parseAttestationReport(reportBuffer);
-
-        if (report.isDebugEnabled) {
-            throw new Error("POLICY CHECK FAILED: Debug mode is ALLOWED. Environment is compromised.");
-        }
-
-        const certBuffer = base64ToUint8Array(teeAttestation.vlek_cert);
-
-        await verifyAMDChain(certBuffer);
-        verifyTCB(certBuffer, report);
-        await verifyHardwareSignature(reportBuffer, certBuffer);
-        await verifyReportData(teeAttestation, proof.claimData.context, report);
-
-        return true;
+        return { isVerified: true };
     } catch (error) {
         logger.error('TEE attestation verification failed:', error);
-        return false;
+        return {
+            isVerified: false,
+            error: error instanceof Error ? error.message : String(error),
+        };
     }
 }
 
-function parseAttestationReport(buffer: Uint8Array) {
-    if (buffer.length < 1000) {
-        throw new Error(`Report buffer is too small: ${buffer.length} bytes`);
-    }
-
-    const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
-    const policy = view.getBigUint64(0x08, true);
-    const isDebugEnabled = (policy & (BigInt(1) << BigInt(19))) !== BigInt(0);
-
-    const reported_tcb = {
-        bootloader: buffer[0x38],
-        tee: buffer[0x39],
-        snp: buffer[0x3E],
-        microcode: buffer[0x3F]
-    };
-
-    const reportData = arrayBufferToHex(buffer.subarray(0x50, 0x90)); // 64 bytes
-    return { policy, isDebugEnabled, reported_tcb, reportData };
-}
-
-function getExtValue(certAsn1: any, oidString: string) {
-    const tbsCert = certAsn1.value[0];
-    if (!tbsCert || !tbsCert.value) return null;
-
-    const extBlockWrapper = tbsCert.value.find((node: any) => node.tagClass === forge.asn1.Class.CONTEXT_SPECIFIC && node.type === 3);
-    if (!extBlockWrapper || !extBlockWrapper.value || !extBlockWrapper.value.length) return null;
-
-    const extSequence = extBlockWrapper.value[0];
-    for (const ext of extSequence.value) {
-        const extIdAsn1 = ext.value[0];
-        const extIdStr = forge.asn1.derToOid(extIdAsn1.value);
-        if (extIdStr === oidString) {
-            const extValueAsn1 = ext.value[ext.value.length - 1];
-            const rawOctetStringBytes = extValueAsn1.value;
-            try {
-                // The extension value is an OCTET STRING containing the DER encoding of an INTEGER
-                const innerAsn1 = forge.asn1.fromDer(forge.util.createBuffer(rawOctetStringBytes));
-                if (innerAsn1.type === 2) { // INTEGER
-                    const bytes = innerAsn1.value;
-                    if (typeof bytes === 'string' && bytes.length > 0) {
-                        return bytes.charCodeAt(bytes.length - 1);
-                    } else {
-                        throw new Error(`Extension ${oidString} INTEGER value is empty or invalid`);
-                    }
-                } else {
-                    throw new Error(`Extension ${oidString} does not contain an INTEGER, found type ${innerAsn1.type}`);
-                }
-            } catch (e) {
-                // Fail closed on any parse or schema error
-                throw new Error(`Failed to strictly parse AMD TCB extension ${oidString}: ${(e as Error).message}`);
-            }
-        }
-    }
-    return null;
-}
-
-function verifyTCB(vlekCertBuffer: Uint8Array, report: any) {
-    const certAsn1 = forge.asn1.fromDer(forge.util.createBuffer(uint8ArrayToBinaryString(vlekCertBuffer)));
-
-    const OID_BOOTLOADER = '1.3.6.1.4.1.3704.1.3.1';
-    const OID_TEE = '1.3.6.1.4.1.3704.1.3.2';
-    const OID_SNP = '1.3.6.1.4.1.3704.1.3.3';
-    const OID_MICROCODE = '1.3.6.1.4.1.3704.1.3.8';
-
-    const certTcb = {
-        bootloader: getExtValue(certAsn1, OID_BOOTLOADER),
-        tee: getExtValue(certAsn1, OID_TEE),
-        snp: getExtValue(certAsn1, OID_SNP),
-        microcode: getExtValue(certAsn1, OID_MICROCODE)
-    };
-
-    if (certTcb.bootloader !== null && report.reported_tcb.bootloader < certTcb.bootloader) {
-        throw new Error(`TCB Downgrade! Bootloader reported ${report.reported_tcb.bootloader}, but certificate requires ${certTcb.bootloader}`);
-    }
-    if (certTcb.tee !== null && report.reported_tcb.tee < certTcb.tee) {
-        throw new Error(`TCB Downgrade! TEE reported ${report.reported_tcb.tee}, but certificate requires ${certTcb.tee}`);
-    }
-    if (certTcb.snp !== null && report.reported_tcb.snp < certTcb.snp) {
-        throw new Error(`TCB Downgrade! SNP reported ${report.reported_tcb.snp}, but certificate requires ${certTcb.snp}`);
-    }
-    if (certTcb.microcode !== null && report.reported_tcb.microcode < certTcb.microcode) {
-        throw new Error(`TCB Downgrade! Microcode reported ${report.reported_tcb.microcode}, but certificate requires ${certTcb.microcode}`);
-    }
-}
-
-function parseAsn1Time(node: any): Date {
-    const s = node.value as string;
-    if (node.type === forge.asn1.Type.UTCTIME) {
-        // UTCTime: YYMMDDHHmmssZ
-        const yr = parseInt(s.substring(0, 2), 10);
-        return new Date(Date.UTC(
-            yr >= 50 ? 1900 + yr : 2000 + yr,
-            parseInt(s.substring(2, 4), 10) - 1,
-            parseInt(s.substring(4, 6), 10),
-            parseInt(s.substring(6, 8), 10),
-            parseInt(s.substring(8, 10), 10),
-            parseInt(s.substring(10, 12), 10)
-        ));
-    } else {
-        // GeneralizedTime: YYYYMMDDHHmmssZ
-        return new Date(Date.UTC(
-            parseInt(s.substring(0, 4), 10),
-            parseInt(s.substring(4, 6), 10) - 1,
-            parseInt(s.substring(6, 8), 10),
-            parseInt(s.substring(8, 10), 10),
-            parseInt(s.substring(10, 12), 10),
-            parseInt(s.substring(12, 14), 10)
-        ));
-    }
-}
-
-async function verifyCRL(crlBuf: Uint8Array, arkPem: string, vlekSerial: string): Promise<void> {
-    // Parse CRL: CertificateList SEQUENCE { TBSCertList, signatureAlgorithm, signatureValue }
-    const crlAsn1 = forge.asn1.fromDer(forge.util.createBuffer(uint8ArrayToBinaryString(crlBuf)));
-
-    if (!Array.isArray(crlAsn1.value) || crlAsn1.value.length < 3) {
-        throw new Error('CRL ASN.1 structure is invalid: expected SEQUENCE with TBSCertList, AlgorithmIdentifier, BIT STRING');
-    }
-
-    const tbsAsn1 = (crlAsn1.value as any[])[0];
-    const sigBitsAsn1 = (crlAsn1.value as any[])[2]; // BIT STRING containing the signature
-
-    if (!Array.isArray(tbsAsn1.value)) {
-        throw new Error('CRL TBSCertList is not a valid SEQUENCE');
-    }
-
-    const tbsFields = tbsAsn1.value as any[];
-    let fi = 0;
-
-    // Optional version field (UNIVERSAL INTEGER — present in CRL v2)
-    if (fi < tbsFields.length &&
-        tbsFields[fi].tagClass === forge.asn1.Class.UNIVERSAL &&
-        tbsFields[fi].type === forge.asn1.Type.INTEGER) {
-        fi++;
-    }
-
-    // signature AlgorithmIdentifier (skip, matches outer signatureAlgorithm)
-    if (fi < tbsFields.length) fi++;
-
-    // issuer Name
-    if (fi >= tbsFields.length) throw new Error('CRL TBSCertList missing issuer');
-    const issuerAsn1 = tbsFields[fi++];
-
-    // thisUpdate (UTCTime or GeneralizedTime)
-    if (fi >= tbsFields.length) throw new Error('CRL TBSCertList missing thisUpdate');
-    const thisUpdateAsn1 = tbsFields[fi++];
-
-    // nextUpdate (optional — UTCTime or GeneralizedTime)
-    let nextUpdateAsn1: any = null;
-    if (fi < tbsFields.length &&
-        tbsFields[fi].tagClass === forge.asn1.Class.UNIVERSAL &&
-        (tbsFields[fi].type === forge.asn1.Type.UTCTIME ||
-            tbsFields[fi].type === forge.asn1.Type.GENERALIZEDTIME)) {
-        nextUpdateAsn1 = tbsFields[fi++];
-    }
-
-    // revokedCertificates (optional UNIVERSAL SEQUENCE; skip context-specific extensions)
-    let revokedSeq: any = null;
-    if (fi < tbsFields.length &&
-        tbsFields[fi].tagClass === forge.asn1.Class.UNIVERSAL &&
-        tbsFields[fi].type === forge.asn1.Type.SEQUENCE) {
-        revokedSeq = tbsFields[fi];
-    }
-
-    // 1. Validity Period
-    const now = new Date();
-    const thisUpdate = parseAsn1Time(thisUpdateAsn1);
-    if (thisUpdate > now) {
-        throw new Error(`CRL is not yet valid: thisUpdate is ${thisUpdate.toISOString()}`);
-    }
-    if (nextUpdateAsn1) {
-        const nextUpdate = parseAsn1Time(nextUpdateAsn1);
-        if (nextUpdate < now) {
-            throw new Error(`CRL has expired: nextUpdate was ${nextUpdate.toISOString()}`);
-        }
-    }
-
-    // 2. Issuer Verification — compare CRL issuer DER bytes to ARK certificate subject DER bytes
-    // The AMD VLEK CRL is issued by the ARK (CN=ARK-Milan/Genoa), not the ASK
-    const crlIssuerDer = forge.asn1.toDer(issuerAsn1).getBytes();
-    const arkForgeCert = forge.pki.certificateFromPem(arkPem);
-    const arkCertAsn1 = forge.pki.certificateToAsn1(arkForgeCert);
-    // TBSCertificate field order: [0]version, serial, sigAlg, issuer, validity, subject, spki, ...
-    const arkSubjectAsn1 = ((arkCertAsn1.value as any[])[0].value as any[])[5];
-    const arkSubjectDer = forge.asn1.toDer(arkSubjectAsn1).getBytes();
-    if (crlIssuerDer !== arkSubjectDer) {
-        throw new Error('CRL issuer does not match AMD ARK certificate subject — chain mismatch');
-    }
-
-    // 3. Signature Verification (AMD CRL uses RSA-PSS with SHA-384, signed by ARK)
-    const tbsDerBuf = binaryStringToUint8Array(forge.asn1.toDer(tbsAsn1).getBytes());
-    // BIT STRING first byte = unused bits count, skip it
-    const sigRaw = typeof sigBitsAsn1.value === 'string' ? sigBitsAsn1.value : '';
-    const sigBuf = binaryStringToUint8Array(sigRaw.substring(1));
-
-    const cryptoSubtle = getSubtleCrypto();
-    const spkiBuf = binaryStringToUint8Array(
-        forge.asn1.toDer(forge.pki.publicKeyToAsn1(arkForgeCert.publicKey)).getBytes()
-    );
-    const arkCryptoKey = await cryptoSubtle.importKey(
-        'spki', spkiBuf,
-        { name: 'RSA-PSS', hash: 'SHA-384' },
-        false, ['verify']
-    );
-    const isValid = await cryptoSubtle.verify(
-        { name: 'RSA-PSS', saltLength: 48 }, // SHA-384 salt length is 48
-        arkCryptoKey,
-        sigBuf,
-        tbsDerBuf
-    );
-    if (!isValid) {
-        throw new Error('CRL signature is INVALID — the CRL may be tampered or forged');
-    }
-
-    // 4. Revocation Check — only inspect the revokedCertificates list, not arbitrary ASN.1 nodes
-    const targetSerial = normalizeSerial(vlekSerial);
-    if (revokedSeq && Array.isArray(revokedSeq.value)) {
-        for (const entry of revokedSeq.value) {
-            if (!Array.isArray(entry.value) || entry.value.length < 2) continue;
-            const serialAsn1 = entry.value[0];
-            if (serialAsn1.type !== forge.asn1.Type.INTEGER || typeof serialAsn1.value !== 'string') continue;
-            const serialHex = forge.util.bytesToHex(serialAsn1.value);
-            if (normalizeSerial(serialHex) === targetSerial) {
-                throw new Error('🚨 VLEK Certificate is REVOKED per AMD CRL! This hardware may be compromised.');
-            }
-        }
-    }
-}
-
-function assertCertValidity(label: string, cert: ParsedCert) {
-    const now = Date.now();
-    if (cert.notBefore && now < cert.notBefore.getTime()) {
-        throw new Error(`${label} certificate is not yet valid (notBefore: ${cert.notBefore.toISOString()})`);
-    }
-    if (cert.notAfter && now > cert.notAfter.getTime()) {
-        throw new Error(`${label} certificate expired on ${cert.notAfter.toISOString()}`);
-    }
-}
-
-async function verifyAMDChain(vlekCertBuffer: Uint8Array) {
-    const processors = ['Milan', 'Genoa'];
-    let chainVerified = false;
-
-    const vlek = parseCert(vlekCertBuffer);
-    assertCertValidity('VLEK', vlek);
-
-    for (const processor of processors) {
-        let matchedChain = false;
-        try {
-            const chainPem = AMD_CERTS[processor];
-            if (!chainPem) continue;
-
-            const certs = chainPem.split('-----END CERTIFICATE-----')
-                .map(c => c.trim())
-                .filter(c => c.length > 0)
-                .map(c => c + '\n-----END CERTIFICATE-----\n');
-
-            const askCert = forge.pki.certificateFromPem(certs[0]);
-            const arkCert = forge.pki.certificateFromPem(certs[1]);
-
-            const askDer = forge.asn1.toDer(forge.pki.certificateToAsn1(askCert)).getBytes();
-            const arkDer = forge.asn1.toDer(forge.pki.certificateToAsn1(arkCert)).getBytes();
-            const ask = parseCert(binaryStringToUint8Array(askDer));
-            const ark = parseCert(binaryStringToUint8Array(arkDer));
-            assertCertValidity('ASK', ask);
-            assertCertValidity('ARK', ark);
-
-            // ARK -> ASK -> VLEK
-            try {
-                await verifySignature(certs[1], ark.tbsDer, ark.signature, ark.sigAlgOid); // ARK Self-signed
-            } catch (e: any) { throw new Error(`AMD ARK self-signature verification failed: ${e.message}`); }
-
-            try {
-                await verifySignature(certs[1], ask.tbsDer, ask.signature, ask.sigAlgOid); // ASK signed by ARK
-            } catch (e: any) { throw new Error(`AMD ASK-by-ARK signature verification failed: ${e.message}`); }
-
-            try {
-                await verifySignature(certs[0], vlek.tbsDer, vlek.signature, vlek.sigAlgOid); // VLEK signed by ASK
-            } catch (e: any) { throw new Error(`VLEK-by-ASK signature verification failed: ${e.message}`); }
-
-            matchedChain = true;
-
-            // Check CRL
-            let crlBuf: Uint8Array | undefined;
-            const now = Date.now();
-            if (crlCache[processor] && now - crlCache[processor].fetchedAt < 3600000) {
-                crlBuf = crlCache[processor].buffer;
-            } else {
-                const crlUrl = `https://kdsintf.amd.com/vlek/v1/${processor}/crl`;
-                const controller = new AbortController();
-                const timeoutId = setTimeout(() => controller.abort(), 5000);
-                const crlResp = await fetch(crlUrl, { signal: controller.signal });
-                clearTimeout(timeoutId);
-
-                if (!crlResp.ok) continue;
-                crlBuf = new Uint8Array(await crlResp.arrayBuffer());
-                crlCache[processor] = { buffer: crlBuf, fetchedAt: now };
-            }
-
-            if (vlek.serialNumber && crlBuf) {
-                await verifyCRL(crlBuf, certs[1], vlek.serialNumber);
-            }
-
-            chainVerified = true;
-            break;
-        } catch (e: any) {
-            if (matchedChain) {
-                throw e; // Hard fail if we matched the chain but CRL fetch/parse failed or cert is revoked
-            }
-            continue;
-        }
-    }
-
-    if (!chainVerified) {
-        throw new Error("VLEK Certificate failed verification against all known AMD Root of Trust chains!");
-    }
-}
-
-async function verifyHardwareSignature(reportBytes: Uint8Array, certBytes: Uint8Array) {
-    const vlek = parseCert(certBytes);
-
-    const sigOffset = 0x2A0;
-    const rLE = reportBytes.subarray(sigOffset, sigOffset + 72);
-    const sLE = reportBytes.subarray(sigOffset + 72, sigOffset + 144);
-
-    const rBE = reverseBytes(rLE);
-    const sBE = reverseBytes(sLE);
-
-    const signedData = reportBytes.subarray(0, 0x2A0);
-
-    const cryptoSubtle = getSubtleCrypto();
-
-    const importedKey = await cryptoSubtle.importKey(
-        "spki",
-        vlek.spkiDer,
-        { name: "ECDSA", namedCurve: "P-384" },
-        false,
-        ["verify"]
-    );
-
-    // the subtle crypto ECDSA signature needs to be raw (r || s), each 48 bytes long
-    // Our rBE and sBE are exactly 72 bytes. P-384 is 48 bytes!
-    // The AMD report reserves 72 bytes for R and 72 bytes for S padded with zeros.
-    // We MUST verify the dropped high-order bytes are zero to prevent malicious tampering.
-    const rPadding = rBE.subarray(0, rBE.length - 48);
-    const sPadding = sBE.subarray(0, sBE.length - 48);
-
-    if (!rPadding.every(b => b === 0) || !sPadding.every(b => b === 0)) {
-        throw new Error("Hardware ECDSA signature is malformed: non-zero padding bytes detected in the structural signature coordinates.");
-    }
-
-    const r48 = rBE.subarray(rBE.length - 48);
-    const s48 = sBE.subarray(sBE.length - 48);
-    const rawSignature = concatUint8Arrays([r48, s48]);
-
-    const isValid = await cryptoSubtle.verify(
-        { name: "ECDSA", hash: { name: "SHA-384" } },
-        importedKey,
-        rawSignature,
-        signedData
-    );
-
-    if (!isValid) {
-        throw new Error("Hardware ECDSA signature is completely invalid!");
-    }
-}
-
-async function verifyReportData(teeAttestation: TeeAttestation, proofContext: string, report: any) {
-    if (!teeAttestation.workload_digest || !teeAttestation.verifier_digest) {
-        throw new Error("POLICY CHECK FAILED: Missing workload_digest or verifier_digest in TEE attestation.");
-    }
-
-    const { attestationNonce: nonce } = JSON.parse(proofContext);
-
-    const cryptoSubtle = getSubtleCrypto();
-
-    // 1. Extract raw 32-byte SHA256 digest from image refs (part after "@sha256:")
-    const extractDigestBytes = (imageRef: string): Uint8Array => {
-        const marker = '@sha256:';
-        const idx = imageRef.lastIndexOf(marker);
-        if (idx < 0) throw new Error(`Image ref missing @sha256: digest: ${imageRef}`);
-        const hexDigest = imageRef.substring(idx + marker.length);
-        if (hexDigest.length !== 64) throw new Error(`SHA256 digest must be 64 hex chars, got ${hexDigest.length} in: ${imageRef}`);
-        const bytes = new Uint8Array(32);
-        for (let i = 0; i < 32; i++) bytes[i] = parseInt(hexDigest.substring(i * 2, i * 2 + 2), 16);
-        return bytes;
-    };
-
-    // 2. Hash COSIGN public key as canonical DER SPKI bytes (not PEM text)
-    const importedCosignKey = await cryptoSubtle.importKey(
-        'spki',
-        base64ToUint8Array(
-            COSIGN_PUBLIC_KEY
-                .replace('-----BEGIN PUBLIC KEY-----', '')
-                .replace('-----END PUBLIC KEY-----', '')
-                .replace(/\s+/g, '')
-        ),
-        { name: 'ECDSA', namedCurve: 'P-256' },
-        true,
-        ['verify']
-    );
-    const pubKeySpkiDer = await cryptoSubtle.exportKey('spki', importedCosignKey);
-    const pubKeyHashBuffer = await cryptoSubtle.digest('SHA-256', pubKeySpkiDer);
-    const pubKeyHashBytes = new Uint8Array(pubKeyHashBuffer);
-
-    // 3. Decode nonce from hex to raw bytes (strip 0x prefix)
-    const nonceHex = (teeAttestation.nonce || nonce).replace(/^0x/i, '');
-    const nonceBytes = new Uint8Array(nonceHex.length / 2);
-    for (let i = 0; i < nonceBytes.length; i++) nonceBytes[i] = parseInt(nonceHex.substring(i * 2, i * 2 + 2), 16);
-
-    // 4. Extract raw digest bytes from image refs
-    const workloadBytes = extractDigestBytes(teeAttestation.workload_digest);
-    const verifierBytes = extractDigestBytes(teeAttestation.verifier_digest);
-
-    // 5. Build canonical binary payload:
-    //    "POPCORN_TEE_REPORT_DATA_V1" || 0x01 || workload(32) || verifier(32) || pubkeyHash(32) || nonceBytes
-    const domainSep = new TextEncoder().encode('POPCORN_TEE_REPORT_DATA_V1');
-    const version = new Uint8Array([0x01]);
-    const payload = new Uint8Array(
-        domainSep.length + version.length +
-        workloadBytes.length + verifierBytes.length +
-        pubKeyHashBytes.length + nonceBytes.length
-    );
-    let offset = 0;
-    for (const chunk of [domainSep, version, workloadBytes, verifierBytes, pubKeyHashBytes, nonceBytes]) {
-        payload.set(chunk, offset);
-        offset += chunk.length;
-    }
-
-    // 6. Compute SHA-256 of the binary payload, duplicate to 64 bytes, compare to report_data
-    const hashBuffer = await cryptoSubtle.digest('SHA-256', payload);
-    const hashHex = arrayBufferToHex(hashBuffer);
-    const expected64ByteHex = hashHex + hashHex;
-
-    if (report.reportData !== expected64ByteHex) {
-        throw new Error(`REPORT_DATA Mismatch! Hardware report is not bound to these image digests or nonce.\nExpected: ${expected64ByteHex}\nGot:      ${report.reportData}`);
-    }
+export async function verifyTeeAttestation(
+    proof: Proof,
+    expectedApplicationId?: string,
+    expectedAppSecret?: string
+): Promise<boolean> {
+    assertNonBrowserEnvironment();
+    const result = await verifyTeeAttestationDetailed(proof, expectedApplicationId, expectedAppSecret);
+    return result.isVerified;
 }


### PR DESCRIPTION
### Description
- verifyTeeAttestation: Changed from (proof) → boolean to (proof, appSecret) → { isVerified, error? }. automatically, enabling application binding and nonce recomputation.
- verifyProof: Renamed config option from verifyTEE: boolean to teeAttestation: { appSecret } so the SDK can verify the attestation was generated for your application.                                                                                                                                      
- Added runTeeVerification(proofs, config) batch helper and exported TeeVerificationError.
- Updated example app to keep app secret server-side only (read from env vars, never sent from client).                                                
- Updated README and CHANGELOG.


### Type of change
- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Documentation update

### Checklist:
- [x] I have read and agree to the [Code of Conduct](https://github.com/reclaimprotocol/.github/blob/main/Code-of-Conduct.md).
- [x] I have signed the [Contributor License Agreement (CLA)](https://github.com/reclaimprotocol/.github/blob/main/CLA.md).
- [x] I have considered the [Security Policy](https://github.com/reclaimprotocol/.github/blob/main/SECURITY.md).
- [x] I have self-reviewed and tested my code.
- [x] I have updated documentation as needed.
- [x] I agree to the [project's custom license](https://github.com/reclaimprotocol/.github/blob/main/LICENSE).

### Additional Notes:
n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * TEE verification now requires an app secret and returns a structured result with success/error (not a boolean).
  * Verification config moved from a simple boolean to a required attestation configuration (app secret required).

* **New Features**
  * Batch TEE verification and server-side verification support.
  * Improved Google Confidential Computing (GCP) TEE attestation flow and stricter binding checks.
  * Example app: on-demand claim flow, paste-and-verify, per-proof TEE badges and summary.

* **Documentation**
  * README updated with GCP OIDC attestation flow, nonce/app binding, and browser vs server guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->