### PR TITLE
Default TEE attestation requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Request TEE attestations by default when initializing proof requests.
+- Include the SDK-controlled TEE attestation version in request templates and attestation nonce context so attestors can keep older SDK clients on compatible proof formats.
+- Add example support for server-side TEE attestation verification and displaying returned TEE proof details.
+
+### Fixed
+
+- Support v3 TEE digest binding verification while keeping v2 verification compatible.
+
 ## [5.2.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [5.3.0]
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -713,13 +713,7 @@ TEE attestation is requested by default during proof generation:
 const proofRequest = await ReclaimProofRequest.init(APP_ID, APP_SECRET, PROVIDER_ID);
 ```
 
-By default, the SDK requests `teeAttestationVersion: 'v3'`. Pin this value when you need to keep an older attestation format alive after a newer default is introduced:
-
-```javascript
-const proofRequest = await ReclaimProofRequest.init(APP_ID, APP_SECRET, PROVIDER_ID, {
-  teeAttestationVersion: 'v3',
-});
-```
+The request includes the SDK's attestation version so the attestor can continue serving older SDK clients when newer attestation formats are introduced.
 
 To opt out, set `acceptTeeAttestation: false` during initialization.
 

--- a/README.md
+++ b/README.md
@@ -705,15 +705,15 @@ const { isVerified } = await verifyProof(proof, {
 
 The SDK supports verifying TEE (Trusted Execution Environment) attestations included in proofs. The attestation flow verifies the Google Confidential Computing OIDC token returned by Popcorn's GCP attestor and checks that it is bound to the proof nonce, application identity, and image digests.
 
-### Enabling TEE Attestation
+### Requesting TEE Attestation
 
-To request TEE attestation during proof generation, enable it during initialization:
+TEE attestation is requested by default during proof generation:
 
 ```javascript
-const proofRequest = await ReclaimProofRequest.init(APP_ID, APP_SECRET, PROVIDER_ID, {
-  acceptTeeAttestation: true,
-});
+const proofRequest = await ReclaimProofRequest.init(APP_ID, APP_SECRET, PROVIDER_ID);
 ```
+
+To opt out, set `acceptTeeAttestation: false` during initialization.
 
 ### Verifying TEE Attestation via `verifyProof`
 

--- a/README.md
+++ b/README.md
@@ -713,6 +713,14 @@ TEE attestation is requested by default during proof generation:
 const proofRequest = await ReclaimProofRequest.init(APP_ID, APP_SECRET, PROVIDER_ID);
 ```
 
+By default, the SDK requests `teeAttestationVersion: 'v3'`. Pin this value when you need to keep an older attestation format alive after a newer default is introduced:
+
+```javascript
+const proofRequest = await ReclaimProofRequest.init(APP_ID, APP_SECRET, PROVIDER_ID, {
+  teeAttestationVersion: 'v3',
+});
+```
+
 To opt out, set `acceptTeeAttestation: false` during initialization.
 
 ### Verifying TEE Attestation via `verifyProof`

--- a/README.md
+++ b/README.md
@@ -701,6 +701,52 @@ const { isVerified } = await verifyProof(proof, {
 });
 ```
 
+### Replay Protection
+
+Proofs are submitted by the user, so the server must not trust any field on the proof in isolation. `verifyProof` (and `verifyTeeAttestation`) cryptographically bind a proof to a specific session, but **the SDK is stateless** — it cannot tell whether the same valid proof has already been verified. Preventing replay is the caller's responsibility.
+
+**What the SDK guarantees**
+
+The `attestationNonce` baked into the proof context is computed as `keccak256("RECLAIM_TEE_NONCE_V1" : applicationId : sessionId : timestamp : appSecret)`. When you call `verifyProof` with `teeAttestation: { appSecret }`, the SDK:
+
+- Recomputes the nonce from `(applicationId, sessionId, timestamp)` in the proof context using **your** `appSecret` and asserts it matches — only the holder of the app secret can mint a valid nonce, so the user cannot rebind a proof to a different `sessionId` or `applicationId`.
+- Confirms the recomputed nonce appears in the TEE attestation token's `eat_nonce` (signed by Google's Confidential Computing OIDC issuer), so the TEE-signed binding cannot be forged either.
+- Asserts the `applicationId` in the nonce data matches the address derived from `appSecret`, and that `sessionId` in the nonce data agrees with `reclaimSessionId` in `claimData.context` and `proxySessionId`/`sessionId` in `claimData.parameters`.
+- Asserts `claimData.timestampS` is within 10 minutes of the nonce timestamp.
+
+In short: the user cannot mutate `sessionId`, `applicationId`, or `timestamp` on a proof without invalidating it. They *can*, however, resubmit the same valid proof.
+
+**What you must do on your server**
+
+1. **Use a session you initiated.** Call `ReclaimProofRequest.init(...)` and `getSessionId()` server-side (or record the `sessionId` returned to your callback). When verifying, reject any proof whose `sessionId` you did not issue.
+2. **Dedupe by `sessionId`.** Persist accepted `sessionId`s (e.g., a unique index in your DB or a TTL cache) and reject a `sessionId` that has already been verified. This is the primary replay defense.
+3. **Require `teeAttestation`** in `verifyProof` for any flow where replay or tampering matters — without it, the cryptographic binding to `appSecret` is not checked.
+4. **Enforce a freshness window.** Reject proofs whose `claimData.timestampS` is older than your business policy allows (the SDK only enforces a 10-minute skew between the nonce timestamp and claim timestamp, not absolute freshness).
+
+```javascript
+// Pseudocode for a server-side verification handler
+const expectedSessionId = await loadSessionForUser(req.user); // session you created
+const sessionId = JSON.parse(proof.claimData.context).reclaimSessionId;
+
+if (sessionId !== expectedSessionId) {
+  throw new Error("session mismatch");
+}
+if (await db.consumedSessions.has(sessionId)) {
+  throw new Error("proof already used"); // replay
+}
+
+const { isVerified, error } = await verifyProof(proof, {
+  ...providerVersion,
+  teeAttestation: { appSecret: process.env.APP_SECRET },
+});
+if (!isVerified) throw error;
+
+await db.consumedSessions.add(sessionId); // mark consumed atomically
+```
+
+> [!WARNING]
+> Without server-side session tracking and dedup, a malicious user can submit the same valid proof repeatedly. The cryptographic checks in `verifyProof` are necessary but not sufficient for replay protection.
+
 ## TEE Attestation Verification
 
 The SDK supports verifying TEE (Trusted Execution Environment) attestations included in proofs. The attestation flow verifies the Google Confidential Computing OIDC token returned by Popcorn's GCP attestor and checks that it is bound to the proof nonce, application identity, and image digests.

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -25,7 +25,7 @@
     },
     "..": {
       "name": "@reclaimprotocol/js-sdk",
-      "version": "5.0.0",
+      "version": "5.3.0",
       "license": "See License in <https://github.com/reclaimprotocol/.github/blob/main/LICENSE>",
       "dependencies": {
         "canonicalize": "^2.0.0",
@@ -2009,23 +2009,6 @@
       "license": "ISC",
       "dependencies": {
         "compare-func": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "../node_modules/@release-it/conventional-changelog/node_modules/conventional-commits-parser": {
-      "version": "6.3.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
       },
       "engines": {
         "node": ">=18"
@@ -8879,6 +8862,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.34.3",
       "cpu": [
@@ -8899,6 +8892,28 @@
         "@img/sharp-libvips-darwin-arm64": "1.2.0"
       }
     },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.3.tgz",
+      "integrity": "sha512-yHpJYynROAj12TA6qil58hmPmAwxKKC7reUqtGLzsOHfP7/rniNGTL8tjWX6L3CTV4+5P4ypcS7Pp+7OB+8ihA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.0"
+      }
+    },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
       "version": "1.2.0",
       "cpu": [
@@ -8909,6 +8924,406 @@
       "os": [
         "darwin"
       ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.0.tgz",
+      "integrity": "sha512-M64XVuL94OgiNHa5/m2YvEQI5q2cl9d/wk0qFTDVXcYzi43lxuiFTftMR1tOnFQovVXNZJ5TURSDK2pNe9Yzqg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.0.tgz",
+      "integrity": "sha512-mWd2uWvDtL/nvIzThLq3fr2nnGfyr/XMXlq8ZJ9WMR6PXijHlC3ksp0IpuhK6bougvQrchUAfzRLnbsen0Cqvw==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.0.tgz",
+      "integrity": "sha512-RXwd0CgG+uPRX5YYrkzKyalt2OJYRiJQ8ED/fi1tq9WQW2jsQIn0tqrlR5l5dr/rjqq6AHAxURhj2DVjyQWSOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.0.tgz",
+      "integrity": "sha512-Xod/7KaDDHkYu2phxxfeEPXfVXFKx70EAFZ0qyUdOjCcxbjqyJOEUpDe6RIyaunGxT34Anf9ue/wuWOqBW2WcQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.0.tgz",
+      "integrity": "sha512-eMKfzDxLGT8mnmPJTNMcjfO33fLiTDsrMlUVcp6b96ETbnJmd4uvZxVJSKPQfS+odwfVaGifhsB07J1LynFehw==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.0.tgz",
+      "integrity": "sha512-ZW3FPWIc7K1sH9E3nxIGB3y3dZkpJlMnkk7z5tu1nSkBoCgw2nSRTFHI5pB/3CQaJM0pdzMF3paf9ckKMSE9Tg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.0.tgz",
+      "integrity": "sha512-UG+LqQJbf5VJ8NWJ5Z3tdIe/HXjuIdo4JeVNADXBFuG7z9zjoegpzzGIyV5zQKi4zaJjnAd2+g2nna8TZvuW9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.0.tgz",
+      "integrity": "sha512-SRYOLR7CXPgNze8akZwjoGBoN1ThNZoqpOgfnOxmWsklTGVfJiGJoC/Lod7aNMGA1jSsKWM1+HRX43OP6p9+6Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.3.tgz",
+      "integrity": "sha512-oBK9l+h6KBN0i3dC8rYntLiVfW8D8wH+NPNT3O/WBHeW0OQWCjfWksLUaPidsrDKpJgXp3G3/hkmhptAW0I3+A==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.0"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.3.tgz",
+      "integrity": "sha512-QdrKe3EvQrqwkDrtuTIjI0bu6YEJHTgEeqdzI3uWJOH6G1O8Nl1iEeVYRGdj1h5I21CqxSvQp1Yv7xeU3ZewbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.0"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.3.tgz",
+      "integrity": "sha512-GLtbLQMCNC5nxuImPR2+RgrviwKwVql28FWZIW1zWruy6zLgA5/x2ZXk3mxj58X/tszVF69KK0Is83V8YgWhLA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.0"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.3.tgz",
+      "integrity": "sha512-3gahT+A6c4cdc2edhsLHmIOXMb17ltffJlxR0aC2VPZfwKoTGZec6u5GrFgdR7ciJSsHT27BD3TIuGcuRT0KmQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.0"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.3.tgz",
+      "integrity": "sha512-8kYso8d806ypnSq3/Ly0QEw90V5ZoHh10yH0HnrzOCr6DKAPI6QVHvwleqMkVQ0m+fc7EH8ah0BB0QPuWY6zJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.0"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.3.tgz",
+      "integrity": "sha512-vAjbHDlr4izEiXM1OTggpCcPg9tn4YriK5vAjowJsHwdBIdx0fYRsURkxLG2RLm9gyBq66gwtWI8Gx0/ov+JKQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.0"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.3.tgz",
+      "integrity": "sha512-gCWUn9547K5bwvOn9l5XGAEjVTTRji4aPTqLzGXHvIr6bIDZKNTA34seMPgM0WmSf+RYBH411VavCejp3PkOeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.0"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.3.tgz",
+      "integrity": "sha512-+CyRcpagHMGteySaWos8IbnXcHgfDn7pO2fiC2slJxvNq9gDipYBN42/RagzctVRKgxATmfqOSulgZv5e1RdMg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.4.4"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.3.tgz",
+      "integrity": "sha512-MjnHPnbqMXNC2UgeLJtX4XqoVHHlZNd+nPt1kRPmj63wURegwBhZlApELdtxM2OIZDRv/DFtLcNhVbd1z8GYXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.3.tgz",
+      "integrity": "sha512-xuCdhH44WxuXgOM714hn4amodJMZl3OEvf0GVTm0BEyMeA2to+8HEdRPShH0SLYptJY1uBw+SCFP9WVQi1Q/cw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.3.tgz",
+      "integrity": "sha512-OWwz05d++TxzLEv4VnsTz5CmZ6mI6S05sfQGEMrNrQcOEERbX46332IvE7pO/EUiw7jUrrS40z/M7kPyjfl04g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reclaimprotocol/js-sdk",
-  "version": "5.1.0",
+  "version": "5.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@reclaimprotocol/js-sdk",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "See License in <https://github.com/reclaimprotocol/.github/blob/main/LICENSE>",
       "dependencies": {
         "canonicalize": "^2.0.0",
@@ -94,7 +94,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -955,7 +954,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -979,7 +977,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2491,7 +2488,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -3358,8 +3354,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.1.tgz",
       "integrity": "sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/node-forge": {
       "version": "1.3.14",
@@ -4077,7 +4072,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4701,7 +4695,6 @@
       "integrity": "sha512-RfOq/Cqy9xV9bOA8N+ZH6DlrDR+5S3Mi0B5kACEjESpE+AviIpAptx9a9cFpWCCvgRtWT+0BbUw+e1BZfts9jg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@simple-libs/stream-utils": "^1.2.0",
         "meow": "^13.0.0"
@@ -4719,7 +4712,6 @@
       "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4894,7 +4886,6 @@
       "integrity": "sha512-20pyHgnO40rvfI0NGF/xiEoFMkXDtkF8FwHvk5BokoFoCuTQRI8vrNCNFWUOfuolKJMm1tPCHc8GgYEtr1XRNA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "meow": "^13.0.0"
       },
@@ -4918,7 +4909,6 @@
       "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
@@ -5348,7 +5338,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6691,7 +6680,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -7363,7 +7351,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -9227,7 +9214,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nodeutils/defaults-deep": "1.1.0",
         "@octokit/rest": "22.0.1",
@@ -10273,7 +10259,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10459,7 +10444,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10640,7 +10624,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reclaimprotocol/js-sdk",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "Designed to request proofs from the Reclaim protocol and manage the flow of claims and witness interactions.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -75,6 +75,13 @@ const SDK_TEE_ATTESTATION_VERSION = 'v3' as const;
  * * `getProviderHashRequirementsFromSpec()` - To get the expected proof hash requirements from a provider spec.
  * * All 3 functions above are alternatives of each other and result from these functions can be directly used as `config` parameter in this function for proof validation.
  *
+ * Replay protection: this function is stateless. It verifies that a proof is cryptographically
+ * bound to a specific `sessionId`/`applicationId` (via the `appSecret`-keyed attestation nonce
+ * when `teeAttestation` is provided) but does not track which proofs have already been
+ * verified. Callers must (a) verify the proof's `sessionId` matches a session they initiated
+ * and (b) persist accepted `sessionId`s and reject duplicates. See the README's
+ * "Replay Protection" section for details.
+ *
  * @param proofOrProofs - A single proof object or an array of proof objects to be verified.
  * @param config - Verification configuration that specifies required hashes, allowed extra hashes, or disables content validation. Optionally includes `teeAttestation` to require TEE attestation verification.
  * @returns Verification result with `isVerified`, `isTeeAttestationVerified` (always boolean), extracted `data` from each proof, and optional `error` on failure. The application ID is derived from `appSecret` automatically.

--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -405,7 +405,12 @@ export class ReclaimProofRequest {
                 }
             }
 
-            const proofRequestInstance = new ReclaimProofRequest(applicationId, providerId, options)
+            const proofRequestOptions = {
+                ...options,
+                acceptTeeAttestation: options?.acceptTeeAttestation ?? true
+            };
+
+            const proofRequestInstance = new ReclaimProofRequest(applicationId, providerId, proofRequestOptions)
 
             const signature = await proofRequestInstance.generateSignature(appSecret)
             proofRequestInstance.setSignature(signature)
@@ -415,7 +420,7 @@ export class ReclaimProofRequest {
             proofRequestInstance.resolvedProviderVersion = data.resolvedProviderVersion
             proofRequestInstance.context.reclaimSessionId = data.sessionId
 
-            if (options?.acceptTeeAttestation) {
+            if (proofRequestOptions.acceptTeeAttestation) {
                 const attestationNonce = generateAttestationNonce(
                     appSecret,
                     applicationId,

--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -4,7 +4,6 @@ import {
     RECLAIM_EXTENSION_ACTIONS,
     ExtensionMessage,
     ProviderVersionInfo,
-    SUPPORTED_TEE_ATTESTATION_VERSIONS,
 } from './utils/interfaces'
 import {
     ProofRequestOptions,
@@ -63,7 +62,7 @@ import { fetchProviderHashRequirementsBy, ProviderHashRequirementsConfig } from 
 const logger = loggerModule.logger
 
 const sdkVersion = require('../package.json').version;
-const DEFAULT_TEE_ATTESTATION_VERSION = 'v3' as const;
+const SDK_TEE_ATTESTATION_VERSION = 'v3' as const;
 
 /**
  * Verifies one or more Reclaim proofs by validating signatures, verifying witness information,
@@ -411,20 +410,11 @@ export class ReclaimProofRequest {
                         }
                     }, 'the constructor');
                 }
-                if (options.teeAttestationVersion) {
-                    validateFunctionParams([
-                        { paramName: 'teeAttestationVersion', input: options.teeAttestationVersion, isString: true }
-                    ], 'the constructor');
-                    if (!(SUPPORTED_TEE_ATTESTATION_VERSIONS as readonly string[]).includes(options.teeAttestationVersion)) {
-                        throw new InvalidParamError(`Invalid teeAttestationVersion. Expected one of: ${SUPPORTED_TEE_ATTESTATION_VERSIONS.join(', ')}`);
-                    }
-                }
             }
 
             const proofRequestOptions = {
                 ...options,
-                acceptTeeAttestation: options?.acceptTeeAttestation ?? true,
-                teeAttestationVersion: options?.teeAttestationVersion ?? DEFAULT_TEE_ATTESTATION_VERSION
+                acceptTeeAttestation: options?.acceptTeeAttestation ?? true
             };
 
             const proofRequestInstance = new ReclaimProofRequest(applicationId, providerId, proofRequestOptions)
@@ -449,7 +439,7 @@ export class ReclaimProofRequest {
                     applicationId,
                     sessionId: data.sessionId,
                     timestamp: proofRequestInstance.timeStamp,
-                    attestationVersion: proofRequestOptions.teeAttestationVersion
+                    attestationVersion: SDK_TEE_ATTESTATION_VERSION
                 })
             }
 
@@ -594,15 +584,6 @@ export class ReclaimProofRequest {
                     }
                 }, 'fromJsonString');
             }
-            if (options?.teeAttestationVersion) {
-                validateFunctionParams([
-                    { paramName: 'options.teeAttestationVersion', input: options.teeAttestationVersion, isString: true }
-                ], 'fromJsonString');
-                if (!(SUPPORTED_TEE_ATTESTATION_VERSIONS as readonly string[]).includes(options.teeAttestationVersion)) {
-                    throw new InvalidParamError(`Invalid options.teeAttestationVersion. Expected one of: ${SUPPORTED_TEE_ATTESTATION_VERSIONS.join(', ')}`);
-                }
-            }
-
             const proofRequestInstance = new ReclaimProofRequest(applicationId, providerId, options);
             proofRequestInstance.sessionId = sessionId;
             proofRequestInstance.context = context;
@@ -1238,7 +1219,7 @@ export class ReclaimProofRequest {
             metadata: this.options?.metadata,
             preferredLocale: this.options?.preferredLocale,
             acceptTeeAttestation: this.options?.acceptTeeAttestation,
-            teeAttestationVersion: this.options?.teeAttestationVersion,
+            teeAttestationVersion: this.context.attestationNonceData?.attestationVersion ?? SDK_TEE_ATTESTATION_VERSION,
         }
 
         return templateData;

--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -1,4 +1,11 @@
-import { type Proof, type Context, RECLAIM_EXTENSION_ACTIONS, ExtensionMessage, ProviderVersionInfo } from './utils/interfaces'
+import {
+    type Proof,
+    type Context,
+    RECLAIM_EXTENSION_ACTIONS,
+    ExtensionMessage,
+    ProviderVersionInfo,
+    SUPPORTED_TEE_ATTESTATION_VERSIONS,
+} from './utils/interfaces'
 import {
     ProofRequestOptions,
     StartSessionParams,
@@ -56,6 +63,7 @@ import { fetchProviderHashRequirementsBy, ProviderHashRequirementsConfig } from 
 const logger = loggerModule.logger
 
 const sdkVersion = require('../package.json').version;
+const DEFAULT_TEE_ATTESTATION_VERSION = 'v3' as const;
 
 /**
  * Verifies one or more Reclaim proofs by validating signatures, verifying witness information,
@@ -403,11 +411,20 @@ export class ReclaimProofRequest {
                         }
                     }, 'the constructor');
                 }
+                if (options.teeAttestationVersion) {
+                    validateFunctionParams([
+                        { paramName: 'teeAttestationVersion', input: options.teeAttestationVersion, isString: true }
+                    ], 'the constructor');
+                    if (!(SUPPORTED_TEE_ATTESTATION_VERSIONS as readonly string[]).includes(options.teeAttestationVersion)) {
+                        throw new InvalidParamError(`Invalid teeAttestationVersion. Expected one of: ${SUPPORTED_TEE_ATTESTATION_VERSIONS.join(', ')}`);
+                    }
+                }
             }
 
             const proofRequestOptions = {
                 ...options,
-                acceptTeeAttestation: options?.acceptTeeAttestation ?? true
+                acceptTeeAttestation: options?.acceptTeeAttestation ?? true,
+                teeAttestationVersion: options?.teeAttestationVersion ?? DEFAULT_TEE_ATTESTATION_VERSION
             };
 
             const proofRequestInstance = new ReclaimProofRequest(applicationId, providerId, proofRequestOptions)
@@ -431,7 +448,8 @@ export class ReclaimProofRequest {
                 proofRequestInstance.setAttestationContext(attestationNonce, {
                     applicationId,
                     sessionId: data.sessionId,
-                    timestamp: proofRequestInstance.timeStamp
+                    timestamp: proofRequestInstance.timeStamp,
+                    attestationVersion: proofRequestOptions.teeAttestationVersion
                 })
             }
 
@@ -575,6 +593,14 @@ export class ReclaimProofRequest {
                         }
                     }
                 }, 'fromJsonString');
+            }
+            if (options?.teeAttestationVersion) {
+                validateFunctionParams([
+                    { paramName: 'options.teeAttestationVersion', input: options.teeAttestationVersion, isString: true }
+                ], 'fromJsonString');
+                if (!(SUPPORTED_TEE_ATTESTATION_VERSIONS as readonly string[]).includes(options.teeAttestationVersion)) {
+                    throw new InvalidParamError(`Invalid options.teeAttestationVersion. Expected one of: ${SUPPORTED_TEE_ATTESTATION_VERSIONS.join(', ')}`);
+                }
             }
 
             const proofRequestInstance = new ReclaimProofRequest(applicationId, providerId, options);
@@ -1211,6 +1237,8 @@ export class ReclaimProofRequest {
             canAutoSubmit: this.options?.canAutoSubmit ?? true,
             metadata: this.options?.metadata,
             preferredLocale: this.options?.preferredLocale,
+            acceptTeeAttestation: this.options?.acceptTeeAttestation,
+            teeAttestationVersion: this.options?.teeAttestationVersion,
         }
 
         return templateData;

--- a/src/__tests__/verify_proof.test.ts
+++ b/src/__tests__/verify_proof.test.ts
@@ -78,10 +78,24 @@ function signJwt(payload: Record<string, any>): string {
     return `${signingInput}.${signature}`;
 }
 
-function createDigestBinding(workloadImageDigest: string, verifierImageDigest: string): string {
-    return createHash('sha256')
-        .update(`${workloadImageDigest}\n${verifierImageDigest}`)
-        .digest('hex');
+function createDigestBinding(
+    proofVersion: string,
+    workloadContainerName: string,
+    workloadImageDigest: string,
+    verifierContainerName: string,
+    verifierImageDigest: string
+): string {
+    const payload = proofVersion === 'v3'
+        ? [
+            'v3',
+            `workload.container_name=${workloadContainerName}`,
+            `workload.image_digest=${workloadImageDigest}`,
+            `verifier.container_name=${verifierContainerName}`,
+            `verifier.image_digest=${verifierImageDigest}`,
+        ].join('\n')
+        : `${workloadImageDigest}\n${verifierImageDigest}`;
+
+    return createHash('sha256').update(payload).digest('hex');
 }
 
 function createGcpTeeAttestation(
@@ -90,7 +104,10 @@ function createGcpTeeAttestation(
     claimsOverrides: Record<string, any> = {}
 ): TeeAttestation {
     const now = Math.floor(Date.now() / 1000);
+    const proofVersion = overrides.proof_version ?? 'v2';
+    const nextWorkloadContainerName = overrides.workload?.container_name ?? 'neko';
     const nextWorkloadDigest = overrides.workload?.image_digest ?? workloadDigest;
+    const nextVerifierContainerName = overrides.verifier?.container_name ?? 'attestor';
     const nextVerifierDigest = overrides.verifier?.image_digest ?? verifierDigest;
 
     const token = signJwt({
@@ -100,7 +117,7 @@ function createGcpTeeAttestation(
         iss: GCP_ISSUER,
         nbf: now - 10,
         sub: 'https://www.googleapis.com/compute/v1/projects/rc-popcorn/zones/asia-south1-c/instances/test-instance',
-        eat_nonce: [nonce, createDigestBinding(nextWorkloadDigest, nextVerifierDigest)],
+        eat_nonce: [nonce, createDigestBinding(proofVersion, nextWorkloadContainerName, nextWorkloadDigest, nextVerifierContainerName, nextVerifierDigest)],
         hwmodel: 'GCP_AMD_SEV',
         secboot: true,
         submods: {
@@ -114,17 +131,17 @@ function createGcpTeeAttestation(
     });
 
     return {
-        proof_version: 'v2',
+        proof_version: proofVersion,
         tee_provider: 'gcp',
         tee_technology: 'amd-sev',
         nonce,
         timestamp: new Date().toISOString(),
         workload: {
-            container_name: 'neko',
+            container_name: nextWorkloadContainerName,
             image_digest: nextWorkloadDigest,
         },
         verifier: {
-            container_name: 'attestor',
+            container_name: nextVerifierContainerName,
             image_digest: nextVerifierDigest,
         },
         attestation: { token },
@@ -139,7 +156,7 @@ function attachLegacyNonceTeeAttestation(proof: Proof): TeeAttestation {
     return teeAttestation;
 }
 
-function attachHashNonceTeeAttestation(proof: Proof, secret = TEST_TEE_SECRET): TeeAttestation {
+function attachHashNonceTeeAttestation(proof: Proof, secret = TEST_TEE_SECRET, overrides: Partial<TeeAttestation> = {}): TeeAttestation {
     const context = JSON.parse(proof.claimData.context);
     // Derive appId from the secret and update the context to match,
     // so verifyTeeAttestation(proof, secret) can verify the binding.
@@ -151,7 +168,7 @@ function attachHashNonceTeeAttestation(proof: Proof, secret = TEST_TEE_SECRET): 
     context.attestationNonce = attestationNonce;
     proof.claimData.context = JSON.stringify(context);
 
-    const teeAttestation = createGcpTeeAttestation(attestationNonce);
+    const teeAttestation = createGcpTeeAttestation(attestationNonce, overrides);
     proof.teeAttestation = teeAttestation;
     return teeAttestation;
 }
@@ -291,8 +308,7 @@ describe('verifyProof', () => {
 
     it('verifies a valid v3 GCP TEE attestation', async () => {
         const proof = cloneProof();
-        const attestation = attachHashNonceTeeAttestation(proof);
-        attestation.proof_version = 'v3';
+        attachHashNonceTeeAttestation(proof, TEST_TEE_SECRET, { proof_version: 'v3' });
 
         const result = await verifyTeeAttestation(proof, TEST_TEE_SECRET);
         expect(result.isVerified).toBe(true);

--- a/src/__tests__/verify_proof.test.ts
+++ b/src/__tests__/verify_proof.test.ts
@@ -289,6 +289,16 @@ describe('verifyProof', () => {
         expect(result.error).toBeUndefined();
     });
 
+    it('verifies a valid v3 GCP TEE attestation', async () => {
+        const proof = cloneProof();
+        const attestation = attachHashNonceTeeAttestation(proof);
+        attestation.proof_version = 'v3';
+
+        const result = await verifyTeeAttestation(proof, TEST_TEE_SECRET);
+        expect(result.isVerified).toBe(true);
+        expect(result.error).toBeUndefined();
+    });
+
     it('fails verification when the wrong app secret is provided', async () => {
         const proof = cloneProof();
         attachHashNonceTeeAttestation(proof);

--- a/src/utils/__tests__/request.test.ts
+++ b/src/utils/__tests__/request.test.ts
@@ -58,7 +58,8 @@ describe('Request', () => {
                 "attestationNonceData": {
                     "applicationId": testAppId,
                     "sessionId": "123",
-                    "timestamp": actualOutput.timestamp
+                    "timestamp": actualOutput.timestamp,
+                    "attestationVersion": "v3"
                 }
             },
             "appCallbackUrl": "https://api.example.com/success?session=def",
@@ -92,6 +93,7 @@ describe('Request', () => {
                     "theme": "dark"
                 },
                 "acceptTeeAttestation": true,
+                "teeAttestationVersion": "v3",
                 "useBrowserExtension": true
             },
             // this can change in future
@@ -177,8 +179,52 @@ describe('Request', () => {
         expect(output.context.attestationNonceData).toEqual({
             applicationId: testAppId,
             sessionId: '999',
-            timestamp: output.timestamp
+            timestamp: output.timestamp,
+            attestationVersion: 'v3'
         });
+    });
+
+    it('should allow pinning the TEE attestation version in the request', async () => {
+        globalThis.fetch = mockFetch({
+            sessionId: '999',
+            resolvedProviderVersion: '1.0.0'
+        });
+
+        const request = await ReclaimProofRequest.init(
+            testAppId,
+            testAppSecret,
+            'example',
+            { teeAttestationVersion: 'v2' }
+        );
+
+        const output = JSON.parse(request.toJsonString());
+        expect(output.options.teeAttestationVersion).toEqual('v2');
+        expect(output.context.attestationNonceData.attestationVersion).toEqual('v2');
+    });
+
+    it('should include the TEE attestation version in the request template', async () => {
+        globalThis.fetch = mockFetch({
+            sessionId: '999',
+            resolvedProviderVersion: '1.0.0'
+        });
+
+        const request = await ReclaimProofRequest.init(
+            testAppId,
+            testAppSecret,
+            'example',
+            { teeAttestationVersion: 'v2' }
+        );
+
+        globalThis.fetch = mockFetchBy(() => ({ success: true }));
+
+        const url = await request.getRequestUrl();
+        const template = new URL(url).searchParams.get('template');
+        const templateData = JSON.parse(decodeURIComponent(template!));
+        const context = JSON.parse(templateData.context);
+
+        expect(templateData.acceptTeeAttestation).toEqual(true);
+        expect(templateData.teeAttestationVersion).toEqual('v2');
+        expect(context.attestationNonceData.attestationVersion).toEqual('v2');
     });
 
     it('should not add TEE attestation context when explicitly disabled', async () => {

--- a/src/utils/__tests__/request.test.ts
+++ b/src/utils/__tests__/request.test.ts
@@ -53,7 +53,13 @@ describe('Request', () => {
             "sessionId": "123",
             "context": {
                 "reclaimSessionId": "123",
-                "user": "john@example.com"
+                "user": "john@example.com",
+                "attestationNonce": actualOutput.context.attestationNonce,
+                "attestationNonceData": {
+                    "applicationId": testAppId,
+                    "sessionId": "123",
+                    "timestamp": actualOutput.timestamp
+                }
             },
             "appCallbackUrl": "https://api.example.com/success?session=def",
             "claimCreationType": "createClaim",
@@ -85,6 +91,7 @@ describe('Request', () => {
                 "metadata": {
                     "theme": "dark"
                 },
+                "acceptTeeAttestation": true,
                 "useBrowserExtension": true
             },
             // this can change in future
@@ -94,6 +101,7 @@ describe('Request', () => {
         };
 
         expect(actualOutput.applicationId).toEqual(testAppId);
+        expect(actualOutput.context.attestationNonce).toEqual(expect.any(String));
         expect(validateSignature(testProviderId, actualOutput.signature, actualOutput.applicationId, actualOutput.timestamp)).toBeUndefined();
         expect(actualOutput).toEqual(expectedOutput);
     });
@@ -164,6 +172,32 @@ describe('Request', () => {
         const output = JSON.parse(request.toJsonString());
         expect(output.options.customSharePageUrl).toEqual('https://portal.reclaimprotocol.org');
         expect(output.options.useAppClip).toEqual(false);
+        expect(output.options.acceptTeeAttestation).toEqual(true);
+        expect(output.context.attestationNonce).toEqual(expect.any(String));
+        expect(output.context.attestationNonceData).toEqual({
+            applicationId: testAppId,
+            sessionId: '999',
+            timestamp: output.timestamp
+        });
+    });
+
+    it('should not add TEE attestation context when explicitly disabled', async () => {
+        globalThis.fetch = mockFetch({
+            sessionId: '999',
+            resolvedProviderVersion: '1.0.0'
+        });
+
+        const request = await ReclaimProofRequest.init(
+            testAppId,
+            testAppSecret,
+            'example',
+            { acceptTeeAttestation: false }
+        );
+
+        const output = JSON.parse(request.toJsonString());
+        expect(output.options.acceptTeeAttestation).toEqual(false);
+        expect(output.context.attestationNonce).toBeUndefined();
+        expect(output.context.attestationNonceData).toBeUndefined();
     });
 
     describe('portalUrl alias', () => {

--- a/src/utils/__tests__/request.test.ts
+++ b/src/utils/__tests__/request.test.ts
@@ -93,7 +93,6 @@ describe('Request', () => {
                     "theme": "dark"
                 },
                 "acceptTeeAttestation": true,
-                "teeAttestationVersion": "v3",
                 "useBrowserExtension": true
             },
             // this can change in future
@@ -184,7 +183,7 @@ describe('Request', () => {
         });
     });
 
-    it('should allow pinning the TEE attestation version in the request', async () => {
+    it('should include the SDK TEE attestation version in the request template', async () => {
         globalThis.fetch = mockFetch({
             sessionId: '999',
             resolvedProviderVersion: '1.0.0'
@@ -193,26 +192,7 @@ describe('Request', () => {
         const request = await ReclaimProofRequest.init(
             testAppId,
             testAppSecret,
-            'example',
-            { teeAttestationVersion: 'v2' }
-        );
-
-        const output = JSON.parse(request.toJsonString());
-        expect(output.options.teeAttestationVersion).toEqual('v2');
-        expect(output.context.attestationNonceData.attestationVersion).toEqual('v2');
-    });
-
-    it('should include the TEE attestation version in the request template', async () => {
-        globalThis.fetch = mockFetch({
-            sessionId: '999',
-            resolvedProviderVersion: '1.0.0'
-        });
-
-        const request = await ReclaimProofRequest.init(
-            testAppId,
-            testAppSecret,
-            'example',
-            { teeAttestationVersion: 'v2' }
+            'example'
         );
 
         globalThis.fetch = mockFetchBy(() => ({ success: true }));
@@ -223,8 +203,8 @@ describe('Request', () => {
         const context = JSON.parse(templateData.context);
 
         expect(templateData.acceptTeeAttestation).toEqual(true);
-        expect(templateData.teeAttestationVersion).toEqual('v2');
-        expect(context.attestationNonceData.attestationVersion).toEqual('v2');
+        expect(templateData.teeAttestationVersion).toEqual('v3');
+        expect(context.attestationNonceData.attestationVersion).toEqual('v3');
     });
 
     it('should not add TEE attestation context when explicitly disabled', async () => {

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -1,5 +1,9 @@
+export const SUPPORTED_TEE_ATTESTATION_VERSIONS = ['v2', 'v3'] as const;
+
+export type TeeAttestationVersion = typeof SUPPORTED_TEE_ATTESTATION_VERSIONS[number];
+
 export interface TeeAttestation {
-  proof_version: string;
+  proof_version: TeeAttestationVersion;
   tee_provider: string;
   tee_technology: string;
   nonce: string;
@@ -79,6 +83,7 @@ export interface Context {
     applicationId: string;
     sessionId: string;
     timestamp: string;
+    attestationVersion?: TeeAttestationVersion;
   };
 }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,4 +1,4 @@
-import type { Context, Proof, ProviderClaimData, TeeAttestation } from './interfaces';
+import type { Context, Proof, ProviderClaimData, TeeAttestation, TeeAttestationVersion } from './interfaces';
 import { VerificationConfig } from './proofValidationUtils';
 import { ProviderHashRequirementsConfig, ReclaimProviderConfigWithRequestSpec, RequestSpec, ResponseMatchSpec, ResponseRedactionSpec } from './providerUtils';
 
@@ -136,6 +136,14 @@ export type ProofRequestOptions = {
    * @default true
    */
   acceptTeeAttestation?: boolean;
+  /**
+   * TEE attestation proof version requested from the verification client.
+   *
+   * Set this explicitly when you need to keep older proof formats alive after a newer default is introduced.
+   *
+   * @default 'v3'
+   */
+  teeAttestationVersion?: TeeAttestationVersion;
 };
 
 export type ReclaimFlowInitOptions = {
@@ -337,6 +345,8 @@ export type TemplateData = {
   canAutoSubmit?: boolean;
   metadata?: Record<string, string>;
   preferredLocale?: ProofRequestOptions['preferredLocale'];
+  acceptTeeAttestation?: boolean;
+  teeAttestationVersion?: ProofRequestOptions['teeAttestationVersion'];
 };
 
 export type TrustedData = {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -136,14 +136,6 @@ export type ProofRequestOptions = {
    * @default true
    */
   acceptTeeAttestation?: boolean;
-  /**
-   * TEE attestation proof version requested from the verification client.
-   *
-   * Set this explicitly when you need to keep older proof formats alive after a newer default is introduced.
-   *
-   * @default 'v3'
-   */
-  teeAttestationVersion?: TeeAttestationVersion;
 };
 
 export type ReclaimFlowInitOptions = {
@@ -346,7 +338,7 @@ export type TemplateData = {
   metadata?: Record<string, string>;
   preferredLocale?: ProofRequestOptions['preferredLocale'];
   acceptTeeAttestation?: boolean;
-  teeAttestationVersion?: ProofRequestOptions['teeAttestationVersion'];
+  teeAttestationVersion?: TeeAttestationVersion;
 };
 
 export type TrustedData = {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -131,7 +131,9 @@ export type ProofRequestOptions = {
    */
   metadata?: Record<string, string>;
   /**
-   * If true, generates a TEE attestation nonce during session initialization and expects a TEE attestation in the proof.
+   * Generates a TEE attestation nonce during session initialization and expects a TEE attestation in the proof.
+   *
+   * @default true
    */
   acceptTeeAttestation?: boolean;
 };

--- a/src/utils/verifyTee.ts
+++ b/src/utils/verifyTee.ts
@@ -337,12 +337,17 @@ function assertAudienceClaim(aud: unknown) {
     throw new Error('attestation token audience is missing');
 }
 
+function getProofVersion(teeAttestation: TeeAttestation): string | undefined {
+    return (teeAttestation as any).proof_version ?? (teeAttestation as any).proofVersion;
+}
+
 function assertProofShape(teeAttestation: TeeAttestation) {
     if (teeAttestation.error) {
         throw new Error(`${teeAttestation.error.code}: ${teeAttestation.error.message}`);
     }
 
-    assert(SUPPORTED_PROOF_VERSIONS.includes(teeAttestation.proof_version), `unexpected proof version: ${teeAttestation.proof_version}`);
+    const proofVersion = getProofVersion(teeAttestation);
+    assert(typeof proofVersion === 'string' && SUPPORTED_PROOF_VERSIONS.includes(proofVersion), `unexpected proof version: ${proofVersion}`);
     assert(teeAttestation.tee_provider === EXPECTED_TEE_PROVIDER, `unexpected tee provider: ${teeAttestation.tee_provider}`);
     assert(teeAttestation.tee_technology === EXPECTED_TEE_TECHNOLOGY, `unexpected tee technology: ${teeAttestation.tee_technology}`);
     assert(typeof teeAttestation.nonce === 'string' && teeAttestation.nonce.length > 0, 'tee attestation nonce missing');
@@ -353,6 +358,27 @@ function assertProofShape(teeAttestation: TeeAttestation) {
     assert(typeof teeAttestation.attestation?.token === 'string' && teeAttestation.attestation.token.length > 0, 'attestation token missing');
 }
 
+async function computeDigestBinding(teeAttestation: TeeAttestation): Promise<string> {
+    const proofVersion = getProofVersion(teeAttestation);
+
+    if (proofVersion === 'v3') {
+        assert(typeof teeAttestation.workload.container_name === 'string' && teeAttestation.workload.container_name.length > 0, 'workload container name missing');
+        assert(typeof teeAttestation.verifier.container_name === 'string' && teeAttestation.verifier.container_name.length > 0, 'verifier container name missing');
+
+        return sha256Hex([
+            'v3',
+            `workload.container_name=${teeAttestation.workload.container_name}`,
+            `workload.image_digest=${teeAttestation.workload.image_digest}`,
+            `verifier.container_name=${teeAttestation.verifier.container_name}`,
+            `verifier.image_digest=${teeAttestation.verifier.image_digest}`,
+        ].join('\n'));
+    }
+
+    return sha256Hex(
+        `${teeAttestation.workload.image_digest}\n${teeAttestation.verifier.image_digest}`
+    );
+}
+
 async function verifyGcpClaims(teeAttestation: TeeAttestation, expectedNonce: string) {
     const claims = await verifyJwtSignature(teeAttestation.attestation.token, EXPECTED_ISSUER);
 
@@ -360,9 +386,7 @@ async function verifyGcpClaims(teeAttestation: TeeAttestation, expectedNonce: st
     assertAudienceClaim(claims.aud);
     assert(Array.isArray(claims.eat_nonce), 'eat_nonce claim missing');
 
-    const digestBinding = await sha256Hex(
-        `${teeAttestation.workload.image_digest}\n${teeAttestation.verifier.image_digest}`
-    );
+    const digestBinding = await computeDigestBinding(teeAttestation);
 
     assert(claims.eat_nonce.includes(expectedNonce), 'request nonce is not present in attestation token');
     assert(claims.eat_nonce.includes(digestBinding), 'digest-binding nonce is not present in attestation token');

--- a/src/utils/verifyTee.ts
+++ b/src/utils/verifyTee.ts
@@ -403,6 +403,10 @@ async function verifyGcpClaims(teeAttestation: TeeAttestation, expectedNonce: st
  * was generated for your application.
  * Returns a result object with `isVerified` and an optional `error` message.
  *
+ * This check is stateless and does not protect against replay of a previously
+ * valid proof. Callers must enforce session matching and dedup `sessionId` on
+ * their server. See the README's "Replay Protection" section.
+ *
  * @param proof - The proof containing TEE attestation data
  * @param appSecret - Your application secret (Ethereum private key). Used to
  *   derive the application ID and recompute the attestation nonce.

--- a/src/utils/verifyTee.ts
+++ b/src/utils/verifyTee.ts
@@ -11,6 +11,7 @@ const EXPECTED_ISSUER = 'https://confidentialcomputing.googleapis.com';
 const EXPECTED_HW_MODEL = 'GCP_AMD_SEV';
 const EXPECTED_TEE_PROVIDER = 'gcp';
 const EXPECTED_TEE_TECHNOLOGY = 'amd-sev';
+const SUPPORTED_PROOF_VERSIONS = ['v2', 'v3'];
 const TOKEN_CLOCK_SKEW_S = 60;
 const NONCE_TIMESTAMP_MAX_SKEW_MS = 10 * 60 * 1000;
 
@@ -341,7 +342,7 @@ function assertProofShape(teeAttestation: TeeAttestation) {
         throw new Error(`${teeAttestation.error.code}: ${teeAttestation.error.message}`);
     }
 
-    assert(teeAttestation.proof_version === 'v2', `unexpected proof version: ${teeAttestation.proof_version}`);
+    assert(SUPPORTED_PROOF_VERSIONS.includes(teeAttestation.proof_version), `unexpected proof version: ${teeAttestation.proof_version}`);
     assert(teeAttestation.tee_provider === EXPECTED_TEE_PROVIDER, `unexpected tee provider: ${teeAttestation.tee_provider}`);
     assert(teeAttestation.tee_technology === EXPECTED_TEE_TECHNOLOGY, `unexpected tee technology: ${teeAttestation.tee_technology}`);
     assert(typeof teeAttestation.nonce === 'string' && teeAttestation.nonce.length > 0, 'tee attestation nonce missing');


### PR DESCRIPTION
## Summary
- default `acceptTeeAttestation` to true during proof request initialization
- preserve explicit opt-out with `acceptTeeAttestation: false`
- update README and request tests for the new default

## Verification
- `npm run build`
- `npm --prefix example run build`
- `npm test -- --runInBand`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TEE attestation is requested by default during proof requests; template data now exposes attestation acceptance and version.

* **Documentation**
  * Added "Replay Protection" guidance with server-side verification steps, freshness/deduplication guidance, and minimal init examples including explicit opt-out.

* **Bug Fixes**
  * Support for multiple TEE proof versions (including v3) and updated digest-binding verification.

* **Tests**
  * Added/updated tests for request serialization, template data, and v3 attestation verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->