### PR TITLE
fix: make cancelSession idempotent

### DIFF
--- a/src/Reclaim.ts
+++ b/src/Reclaim.ts
@@ -1268,6 +1268,7 @@ export class ReclaimProofRequest {
         this.closeModal();
         this.closePortalTab();
         this.closeEmbeddedFlow();
+        this.sessionId = '';
 
         // Best-effort backend update. Swallow errors: by the time we cancel, the
         // user is already leaving, and a backend that has moved the session to a

--- a/src/utils/__tests__/cancelSession.test.ts
+++ b/src/utils/__tests__/cancelSession.test.ts
@@ -33,6 +33,28 @@ describe('cancelSession', () => {
         expect(body).toEqual({ sessionId: '123', status: SessionStatus.SESSION_CANCELLED });
     });
 
+    it('does not cancel the same session more than once', async () => {
+        globalThis.fetch = mockFetch({
+            sessionId: '123',
+            resolvedProviderVersion: '1.0.0'
+        });
+
+        const request = await ReclaimProofRequest.init(
+            testAppId,
+            testAppSecret,
+            'example',
+            { log: false, acceptAiProviders: false }
+        );
+
+        const fetchMock = jest.fn().mockResolvedValue({ ok: true, json: () => ({}) });
+        globalThis.fetch = fetchMock;
+
+        await request.cancelSession();
+        await request.cancelSession();
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
     it('is a no-op when there is no active session', async () => {
         globalThis.fetch = mockFetch({
             sessionId: '123',


### PR DESCRIPTION
### Description

`cancelSession()` is documented as safe to call more than once, but it kept the cancelled session ID, so repeated calls sent duplicate `SESSION_CANCELLED` updates.

Clear the local session ID after stopping the UI and polling, while retaining the captured ID for the best-effort backend update. Add a regression test that calls `cancelSession()` twice and verifies only one update is sent.

### Testing

- `npm test -- --runInBand src/utils/__tests__/cancelSession.test.ts`
- `npx --no-install tsup --dts`

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### Checklist

- [x] I have read and agree to the Code of Conduct.
- [x] I have signed the Contributor License Agreement (CLA).
- [x] I have considered the Security Policy.
- [x] I have self-reviewed and tested my code.
- [x] I have updated documentation as needed.
- [x] I agree to the project's custom license.