### PR TITLE
Add RequestSpec.templateParamsMode to control generateSpecsFromRequestSpecTemplate

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "js/ts.tsdk.path": "node_modules/typescript/lib"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.6.1]
+
+### Added
+
+- `RequestSpec.templateParamsMode` (`'separate' | 'merge'`, defaults to `'separate'`) controls how `generateSpecsFromRequestSpecTemplate` expands a template with multiple `templateParams` values. `'separate'` is the existing/default behavior — one independent spec (and expected hash) per value, matching N separate proofs. `'merge'` is new: it folds every value into a single spec whose `responseMatches`/`responseRedactions` gain one entry per value, matching one proof that bundles many values into a single claim (e.g. a `customInjection` provider that proves 30+ playlist names in one claim instead of 30 separate ones). See the README's "Provider Authors: Validating Dynamically Injected Claims" section for examples.
+
 ## [5.6.0]
 
 - Enable deferred deep links for android by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.6.2]
+
+### Fix
+
+- Inclusion of parameters from `JSON.parse($.claimData.parameters).paramValues` along with `JSON.parse($.claimData.context).extractedParameters`.
+
 ## [5.6.1]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -701,6 +701,48 @@ const { isVerified } = await verifyProof(proof, {
 });
 ```
 
+### 5. Provider Authors: Validating Dynamically Injected Claims
+
+Some providers use a `customInjection` script that calls `window.Reclaim.requestClaim(...)` itself at runtime (a "HAWKEYE" provider), instead of relying only on a fixed, pre-declared request. Because the exact shape of those claims isn't known ahead of time, the provider config carries a separate `allowedInjectedRequestData` list of *templates* — each one describing what's allowed, with `${paramName}` placeholders that get filled in from the proof's own `extractedParameters` at verification time (via `templateParams`).
+
+There are two ways a template can expand, controlled by `templateParamsMode`:
+
+**`'separate'` (default)** — one value produces one independent claim. Use this when the same small claim shape is expected to show up as several separate proofs, e.g. proving a name for each of several employee records one claim at a time:
+
+```javascript
+{
+  url: "https://example.com/api/employee",
+  method: "GET",
+  urlType: "API",
+  bodySniff: { enabled: false, template: "" },
+  responseMatches: [{ type: "contains", value: "\"name\":\"{{${name}}}\"" }],
+  responseRedactions: [{ jsonPath: "$.name" }],
+  templateParams: ["name"],
+  // templateParamsMode: "separate" is the default, no need to set it explicitly
+}
+```
+If the submitted proofs' `extractedParameters` contain `name: ["alex", "bob"]`, this expands into **two** separate expected hashes — one claim proving "alex", another proving "bob".
+
+**`'merge'`** — all values are folded into a single claim. Use this when one claim bundles many values together in one shot, e.g. a single claim that proves 30 playlist names at once:
+
+```javascript
+{
+  url: "https://api-partner.spotify.com/pathfinder/v2/query",
+  method: "POST",
+  urlType: "CONSTANT",
+  bodySniff: { enabled: true, template: "<the libraryV3 request body>" },
+  responseMatches: [{ type: "contains", value: "\"name\":\"{{name_${idx}}}\"" }],
+  responseRedactions: [{ jsonPath: "$.data.me.libraryV3.items[${idx}].item.data.name" }],
+  templateParams: ["idx"],
+  templateParamsMode: "merge",
+}
+```
+If `extractedParameters.idx` is `["1", "2", "3"]`, this expands into **one** claim spec whose `responseMatches`/`responseRedactions` each gain three entries — matching a single proof that bundled all three names into one claim, instead of expecting three separate proofs.
+
+For `'merge'` to work, the claim itself needs to carry the index list as a witness parameter your extraction script controls — e.g. `witnessParameters.idx = JSON.stringify([1, 2, 3])` — since `extractedParameters` values are only treated as arrays when they're already an array or a string that parses into one.
+
+If a provider's injected claims genuinely can't be expressed by either mode (e.g. an unbounded, unpredictable mix of different extraction shapes in one claim), fall back to `dangerouslyDisableContentValidation` for that provider and, if you need some structural assurance beyond the signature check, inspect `JSON.parse(proof.claimData.parameters).url`/`.method` yourself after verification.
+
 ### Replay Protection
 
 Proofs are submitted by the user, so the server must not trust any field on the proof in isolation. `verifyProof` (and `verifyTeeAttestation`) cryptographically bind a proof to a specific session, but **the SDK is stateless** — it cannot tell whether the same valid proof has already been verified. Preventing replay is the caller's responsibility.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reclaimprotocol/js-sdk",
-  "version": "5.6.1",
+  "version": "5.6.2",
   "description": "Designed to request proofs from the Reclaim protocol and manage the flow of claims and witness interactions.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reclaimprotocol/js-sdk",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "Designed to request proofs from the Reclaim protocol and manage the flow of claims and witness interactions.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils/__tests__/spec.test.ts
+++ b/src/utils/__tests__/spec.test.ts
@@ -56,6 +56,56 @@ describe('generateSpecsFromRequestSpecTemplate', () => {
         expect(result[1].responseRedactions[1].regex).toBe('"department":"(?<Bio>.*)"');
     });
 
+    // Bundled claims (e.g. one Spotify libraryV3 claim proving 30+ playlist
+    // names at once) need N values folded into ONE spec, not N separate specs
+    // (see the 'separate' test above, which is the default and remains
+    // unchanged). Opt in via `templateParamsMode: 'merge'`.
+    it('with templateParamsMode "merge" should fold multiple template values into ONE spec with one match/redaction entry per value', () => {
+        const specWithMatches: RequestSpec = {
+            ...baseSpec,
+            responseMatches: [
+                { value: '"id":${idx}', invert: undefined, isOptional: undefined, type: "contains" }
+            ],
+            responseRedactions: [
+                { jsonPath: "$.items[${idx}].id", regex: '', xPath: '' }
+            ],
+            templateParams: ['idx'],
+            templateParamsMode: 'merge',
+        };
+
+        const result = generateSpecsFromRequestSpecTemplate([specWithMatches], { idx: ['1', '2', '3'] });
+
+        // One spec, with one match/redaction per value baked in.
+        expect(result).toHaveLength(1);
+        expect(result[0].responseMatches).toHaveLength(3);
+        expect(result[0].responseMatches[0].value).toBe('"id":1');
+        expect(result[0].responseMatches[1].value).toBe('"id":2');
+        expect(result[0].responseMatches[2].value).toBe('"id":3');
+        expect(result[0].responseRedactions[0].jsonPath).toBe('$.items[1].id');
+        expect(result[0].responseRedactions[1].jsonPath).toBe('$.items[2].id');
+        expect(result[0].responseRedactions[2].jsonPath).toBe('$.items[3].id');
+    });
+
+    it('templateParamsMode "merge" with a single value behaves the same as "separate" for N=1', () => {
+        const specWithMatches: RequestSpec = {
+            ...baseSpec,
+            responseMatches: [
+                { value: '"id":${idx}', invert: undefined, isOptional: undefined, type: "contains" }
+            ],
+            responseRedactions: [
+                { jsonPath: "$.items[${idx}].id", regex: '', xPath: '' }
+            ],
+            templateParams: ['idx'],
+            templateParamsMode: 'merge',
+        };
+
+        const result = generateSpecsFromRequestSpecTemplate([specWithMatches], { idx: ['1'] });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].responseMatches).toHaveLength(1);
+        expect(result[0].responseMatches[0].value).toBe('"id":1');
+    });
+
     it('should not mutate the original template spec', () => {
         const specWithMatches: RequestSpec = {
             ...baseSpec,

--- a/src/utils/providerUtils.ts
+++ b/src/utils/providerUtils.ts
@@ -160,7 +160,17 @@ export function generateSpecsFromRequestSpecTemplate(requestSpecTemplates: Reque
 }
 
 export function takeTemplateParametersFromProofs(proofs?: Proof[]): Record<string, string[]> {
-    return takePairsWhereValueIsArray(proofs?.map(it => JSON.parse(it.claimData.context).extractedParameters as Record<string, string>).reduce((acc, it) => ({ ...acc, ...it }), {}));
+    return takePairsWhereValueIsArray(proofs?.map(it => {
+        let parameters: Record<string, string> = {};
+        let contextParameters: Record<string, string> = {};
+        try {
+            parameters = JSON.parse(it.claimData.parameters).paramValues as Record<string, string>;
+        } catch (_) { }
+        try {
+            contextParameters = JSON.parse(it.claimData.context).extractedParameters as Record<string, string>;
+        } catch (_) { }
+        return { ...parameters, ...contextParameters };
+    }).reduce((acc, it) => ({ ...acc, ...it }), {}));
 }
 
 export function takePairsWhereValueIsArray(o: Record<string, string> | undefined): Record<string, string[]> {

--- a/src/utils/providerUtils.ts
+++ b/src/utils/providerUtils.ts
@@ -45,16 +45,23 @@ export async function fetchProviderHashRequirementsBy(providerId: string, exactP
 
 /**
  * Generates an array of `RequestSpec` objects by replacing template parameters with their corresponding values.
- * 
- * If the input template includes `templateParams` (e.g., `['param1', 'param2']`), this function will 
- * cartesian-map (or pairwise-map) the provided `templateParameters` record (e.g., `{ param1: ['v1', 'v2'], param2: ['a1', 'a2'] }`) 
- * to generate multiple unique `RequestSpec` configurations.
- * 
+ *
+ * If the input template includes `templateParams` (e.g., `['param1', 'param2']`), this function will
+ * cartesian-map (or pairwise-map) the provided `templateParameters` record (e.g., `{ param1: ['v1', 'v2'], param2: ['a1', 'a2'] }`)
+ * to generate `RequestSpec` configurations. How those configurations are shaped is controlled by
+ * `template.templateParamsMode` (defaults to `'separate'`):
+ *
+ * - `'separate'`: each value pair produces its own independent `RequestSpec` — N values in, N
+ *   specs out, each expected to match its own separate proof.
+ * - `'merge'`: all value pairs are folded into a single `RequestSpec`, whose `responseMatches`/
+ *   `responseRedactions` arrays gain one entry per value — N values in, 1 spec out (with N
+ *   entries), expected to match one proof that bundles all N values into a single claim.
+ *
  * The function ensures that:
  * 1. Parameters strictly specified in `template.templateParams` are found.
  * 2. All specified template parameters arrays have the exact same length (pairwise mapping).
  * 3. String replacements are fully applied (all occurrences) to `responseMatches` (value) and `responseRedactions` (jsonPath, xPath, regex).
- * 
+ *
  * @param requestSpecTemplates - The base template `RequestSpec` containing parameter placeholders.
  * @param templateParameters - A record mapping parameter names to arrays of strings representing the extracted values.
  * @returns An array of fully constructed `RequestSpec` objects with templates replaced.
@@ -64,6 +71,28 @@ export function generateSpecsFromRequestSpecTemplate(requestSpecTemplates: Reque
     if (!requestSpecTemplates) return [];
 
     const generatedRequestTemplate: RequestSpec[] = [];
+
+    const getRequestSpecVariableTemplate = (key: string) => {
+        return `\${${key}}`;
+    }
+
+    const substitute = <T extends { value: string }>(match: T, currentTemplateParams: Record<string, string>): T => {
+        const copy = { ...match };
+        for (const [key, value] of Object.entries(currentTemplateParams)) {
+            copy.value = copy.value.split(getRequestSpecVariableTemplate(key)).join(value);
+        }
+        return copy;
+    }
+
+    const substituteRedaction = (redaction: ResponseRedactionSpec, currentTemplateParams: Record<string, string>): ResponseRedactionSpec => {
+        const copy = { ...redaction };
+        for (const [key, value] of Object.entries(currentTemplateParams)) {
+            copy.jsonPath = copy.jsonPath.split(getRequestSpecVariableTemplate(key)).join(value);
+            copy.xPath = copy.xPath.split(getRequestSpecVariableTemplate(key)).join(value);
+            copy.regex = copy.regex.split(getRequestSpecVariableTemplate(key)).join(value);
+        }
+        return copy;
+    }
 
     for (const template of requestSpecTemplates) {
         const templateVariables = template.templateParams ?? [];
@@ -85,8 +114,30 @@ export function generateSpecsFromRequestSpecTemplate(requestSpecTemplates: Reque
             throw new InvalidRequestSpecError(`Not all template variables have same length for template`);
         }
 
-        const getRequestSpecVariableTemplate = (key: string) => {
-            return `\${${key}}`;
+        if (template.templateParamsMode === 'merge') {
+            const mergedMatches: ResponseMatchSpec[] = [];
+            const mergedRedactions: ResponseRedactionSpec[] = [];
+
+            for (let i = 0; i < templateParamsPairMatchLength; i++) {
+                const currentTemplateParams: Record<string, string> = {};
+                for (const [key, values] of templateParamsPairMatch) {
+                    currentTemplateParams[key] = values[i];
+                }
+
+                for (const match of template.responseMatches ?? []) {
+                    mergedMatches.push(substitute(match, currentTemplateParams));
+                }
+                for (const redaction of template.responseRedactions ?? []) {
+                    mergedRedactions.push(substituteRedaction(redaction, currentTemplateParams));
+                }
+            }
+
+            generatedRequestTemplate.push({
+                ...template,
+                responseMatches: mergedMatches,
+                responseRedactions: mergedRedactions,
+            });
+            continue;
         }
 
         for (let i = 0; i < templateParamsPairMatchLength; i++) {
@@ -97,22 +148,8 @@ export function generateSpecsFromRequestSpecTemplate(requestSpecTemplates: Reque
 
             const spec: RequestSpec = {
                 ...template,
-                responseMatches: template.responseMatches ? template.responseMatches.map(m => ({ ...m })) : [],
-                responseRedactions: template.responseRedactions ? template.responseRedactions.map(r => ({ ...r })) : [],
-            }
-
-            for (const match of spec.responseMatches) {
-                for (const [key, value] of Object.entries(currentTemplateParams)) {
-                    match.value = match.value.split(getRequestSpecVariableTemplate(key)).join(value);
-                }
-            }
-
-            for (const redaction of spec.responseRedactions) {
-                for (const [key, value] of Object.entries(currentTemplateParams)) {
-                    redaction.jsonPath = redaction.jsonPath.split(getRequestSpecVariableTemplate(key)).join(value);
-                    redaction.xPath = redaction.xPath.split(getRequestSpecVariableTemplate(key)).join(value);
-                    redaction.regex = redaction.regex.split(getRequestSpecVariableTemplate(key)).join(value);
-                }
+                responseMatches: (template.responseMatches ?? []).map(m => substitute(m, currentTemplateParams)),
+                responseRedactions: (template.responseRedactions ?? []).map(r => substituteRedaction(r, currentTemplateParams)),
             }
 
             generatedRequestTemplate.push(spec);
@@ -283,6 +320,21 @@ export interface RequestSpec {
      * during dynamic request spec construction.
      */
     templateParams?: string[]
+    /**
+     * Controls how a template with multiple values per `templateParams` entry is expanded by
+     * `generateSpecsFromRequestSpecTemplate`.
+     *
+     * - `'separate'` (default): each value produces its own independent `RequestSpec` (and
+     *   therefore its own expected hash), matching N separate proofs. Use this when the same
+     *   small claim shape is expected to appear as N separate proofs (e.g. one proof per employee
+     *   record).
+     * - `'merge'`: all values are folded into a single `RequestSpec`, with one `responseMatches`/
+     *   `responseRedactions` entry generated per value, matching one proof/hash. Use this when a
+     *   single claim bundles many values together (e.g. one claim proving 30 playlist names at
+     *   once) — the shape that `'separate'` cannot express, since it can only ever produce many
+     *   small specs, never one combined spec.
+     */
+    templateParamsMode?: 'separate' | 'merge'
 }
 
 /**


### PR DESCRIPTION
…tSpecTemplate

### Description
<!-- Briefly describe the changes in this PR. -->

### Testing (ignore for documentation update)
<!-- Briefly describe how you've tested this implementation -->

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

### Checklist:
- [x] I have read and agree to the [Code of Conduct](https://github.com/reclaimprotocol/.github/blob/main/Code-of-Conduct.md).
- [x] I have signed the [Contributor License Agreement (CLA)](https://github.com/reclaimprotocol/.github/blob/main/CLA.md).
- [x] I have considered the [Security Policy](https://github.com/reclaimprotocol/.github/blob/main/SECURITY.md).
- [x] I have self-reviewed and tested my code.
- [x] I have updated documentation as needed.
- [x] I agree to the [project's custom license](https://github.com/reclaimprotocol/.github/blob/main/LICENSE).

### Additional Notes:
<!-- Any other context about the PR. -->
