### PR TITLE
fix: avoid required-rule hash explosion

### DIFF
--- a/src/utils/__tests__/witness.test.ts
+++ b/src/utils/__tests__/witness.test.ts
@@ -171,6 +171,58 @@ describe('Witness', () => {
             expect(result).toHaveLength(2); 
         });
 
+        it('should preserve large sets of required rules without enumerating every subset', () => {
+            const responseMatches = Array.from({ length: 32 }, (_, index) => ({
+                type: 'contains' as const,
+                value: `required-${index}`,
+                invert: false,
+                isOptional: false,
+            }));
+            const responseRedactions = Array.from({ length: 32 }, (_, index) => ({
+                jsonPath: `$.required[${index}]`,
+                regex: `required-${index}`,
+                xPath: '',
+            }));
+
+            const result = getProviderParamsAsCanonicalizedString({
+                url: 'https://example.com',
+                method: 'GET',
+                body: '',
+                responseMatches,
+                responseRedactions,
+            });
+
+            expect(result).toEqual([
+                canonicalStringify({
+                    url: 'https://example.com',
+                    method: 'GET',
+                    body: '',
+                    responseMatches: responseMatches.map(({ isOptional: _, ...match }) => ({
+                        ...match,
+                        invert: undefined,
+                    })),
+                    responseRedactions,
+                }),
+            ]);
+        });
+
+        it('should reject an unbounded number of optional-rule combinations', () => {
+            const responseMatches = Array.from({ length: 31 }, (_, index) => ({
+                type: 'contains' as const,
+                value: `optional-${index}`,
+                invert: false,
+                isOptional: true,
+            }));
+
+            expect(() => getProviderParamsAsCanonicalizedString({
+                url: 'https://example.com',
+                method: 'GET',
+                body: '',
+                responseMatches,
+                responseRedactions: [],
+            })).toThrow('Cannot hash more than 30 optional response match rules');
+        });
+
         it('should handle undefined rules properly and return base object', () => {
             const params: HttpProviderClaimParams = { url: 'http://a', method: 'GET', body: '' } as any;
             const result = getProviderParamsAsCanonicalizedString(params);

--- a/src/witness.ts
+++ b/src/witness.ts
@@ -75,7 +75,7 @@ function strToUint8Array(str: string): Uint8Array {
  * starting claim creation to make a valid proof if the server payload may not contain them.
  * 
  * To ensure the eventual Proof's Hash safely validates against the parent template's Requirement Hash, logic here 
- * loops $2^N$ times using bitmask computation (where N = number of rule pairs) and yields canonically sorted 
+ * loops $2^N$ times using bitmask computation (where N = number of optional rule pairs) and yields canonically sorted
  * permutations for every sub-set of optional combinations. 
  * Any combination forcefully omitting a mathematically required (`isOptional: false`) rule is stripped out.
  * 
@@ -89,22 +89,34 @@ function strToUint8Array(str: string): Uint8Array {
 export function getProviderParamsAsCanonicalizedString(params: HttpProviderClaimParams): string[] {
   // redaction cannot be more than response match
   const pairsCount = params?.responseMatches?.length ?? 0;
+  const optionalPairPositions = new Map<number, number>();
   const validCanonicalizedStrings: string[] = [];
 
-  // Total combinations: 2^pairsCount
-  const totalCombinations = 1 << pairsCount;
+  for (let i = 0; i < pairsCount; i++) {
+    if (params.responseMatches[i]?.isOptional) {
+      optionalPairPositions.set(i, optionalPairPositions.size);
+    }
+  }
+
+  if (optionalPairPositions.size > 30) {
+    throw new RangeError('Cannot hash more than 30 optional response match rules');
+  }
+
+  // Required rules are present in every result, so only optional rules need a
+  // bit in the combination mask.
+  const totalCombinations = 1 << optionalPairPositions.size;
 
   for (let i = 0; i < totalCombinations; i++) {
-    let isValidCombination = true;
     let includedCount = 0;
 
     const currentMatches: HashableHttpProviderClaimParams['responseMatches'] = [];
     const currentRedactions: HashableHttpProviderClaimParams['responseRedactions'] = [];
 
     for (let j = 0; j < pairsCount; j++) {
-      const isIncluded = (i & (1 << j)) !== 0;
       const match = params?.responseMatches?.[j];
       const redaction = params?.responseRedactions?.[j];
+      const optionalPosition = optionalPairPositions.get(j);
+      const isIncluded = optionalPosition === undefined || (i & (1 << optionalPosition)) !== 0;
 
       if (isIncluded) {
         if (match) {
@@ -124,15 +136,10 @@ export function getProviderParamsAsCanonicalizedString(params: HttpProviderClaim
           });
         }
         includedCount++;
-      } else {
-        if (match && !match.isOptional) {
-          isValidCombination = false;
-          break;
-        }
       }
     }
 
-    if (isValidCombination && includedCount > 0) {
+    if (includedCount > 0) {
       const filteredParams: HashableHttpProviderClaimParams = {
         url: params?.url ?? '',
         // METHOD needs to be explicitly specified and absence or unknown method should cause error, but we're choosing to ignore it in this case


### PR DESCRIPTION
### Description

Provider hash generation used every response-match pair as a bit in a 32-bit combination mask, even though required rules must be present in every valid result. Required-only specifications therefore grew exponentially and, at 32 required rules, the mask wrapped and returned a base hash with all required matches and redactions removed.

This change enumerates only optional-rule combinations, keeps required rules in every canonicalized result, and rejects more than 30 optional rules instead of silently overflowing.

### Testing

- Added a regression preserving 32 required match/redaction pairs; before the fix it returned empty arrays
- Added an overflow regression for 31 optional rules
- `npx jest src/utils/__tests__/witness.test.ts --runInBand --silent` (12/12)
- `npx tsc --noEmit`
- `npx tsup --dts`
- `git diff --check`

The full suite reaches 150 passing tests. Four existing `verify_proof` failures and the existing Windows/Jest `Uint8Array[Symbol.hasInstance]` setup error reproduce unchanged on clean `main`.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### Checklist

- [ ] I have read and agree to the [Code of Conduct](https://github.com/reclaimprotocol/.github/blob/main/Code-of-Conduct.md).
- [ ] I have signed the [Contributor License Agreement (CLA)](https://github.com/reclaimprotocol/.github/blob/main/CLA.md).
- [x] I have considered the [Security Policy](https://github.com/reclaimprotocol/.github/blob/main/SECURITY.md).
- [x] I have self-reviewed and tested my code.
- [x] I have updated documentation as needed.
- [ ] I agree to the [project's custom license](https://github.com/reclaimprotocol/.github/blob/main/LICENSE).

### Additional notes

The legal acknowledgements are intentionally left unchecked for the contributor to complete personally.